### PR TITLE
RoutineBase JSON results IO

### DIFF
--- a/ams/opt/exprcalc.py
+++ b/ams/opt/exprcalc.py
@@ -102,6 +102,17 @@ class ExpressionCalc(OptzBase):
         else:
             return self.optz.value
 
+    @v.setter
+    def v(self, value):
+        """
+        Set the ExpressionCalc value.
+        """
+        if self.optz is None:
+            raise ValueError("ExpressionCalc is not evaluated yet.")
+        if not isinstance(value, (int, float, np.ndarray)):
+            raise TypeError(f"Value must be a number or numpy array, got {type(value)}.")
+        self.optz.value = value
+
     @property
     def e(self):
         """

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -3,9 +3,9 @@ Module for routine data.
 """
 
 import logging
-from typing import Optional, Union, Type, Iterable, Dict
-from collections import OrderedDict
 import json
+from collections import OrderedDict
+from typing import Optional, Union, Type, Iterable, Dict
 
 import numpy as np
 

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -470,7 +470,6 @@ class RoutineBase:
                     try:
                         var.v = np.array(values)
                     except Exception as e:
-                        print(f"values.shape: {np.array(values).shape}")
                         logger.warning(f"Failed to assign values to var '{key}': {e}")
                 elif key in self.exprs:
                     continue
@@ -480,7 +479,6 @@ class RoutineBase:
                     try:
                         exprc.v = np.array(values)
                     except Exception as e:
-                        print(f"values.shape: {np.array(values).shape}")
                         logger.warning(f"Failed to assign values to exprc '{key}': {e}")
         logger.info(f"Loaded results from {path}")
         return True

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -453,6 +453,9 @@ class RoutineBase:
             logger.error(f"Failed to load JSON file: {e}")
             return False
 
+        if not self.initialized:
+            self.init()
+
         # Unpack variables and expressions from JSON
         for group, group_data in data.items():
             if not isinstance(group_data, dict):

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -5,6 +5,7 @@ Module for routine data.
 import logging
 from typing import Optional, Union, Type, Iterable, Dict
 from collections import OrderedDict
+import json
 
 import numpy as np
 
@@ -430,6 +431,89 @@ class RoutineBase:
             msg += n_iter_str + f"with {sstats.solver_name}!"
             logger.warning(msg)
             return False
+
+    def load_json(self, path):
+        """
+        Load scheduling results from a json file.
+
+        Parameters
+        ----------
+        path : str
+            Path of the json file to load.
+
+        Returns
+        -------
+        bool
+            True if the loading is successful, False otherwise.
+        """
+        try:
+            with open(path, 'r') as f:
+                data = json.load(f)
+        except Exception as e:
+            logger.error(f"Failed to load JSON file: {e}")
+            return False
+
+        # Unpack variables and expressions from JSON
+        for group, group_data in data.items():
+            if not isinstance(group_data, dict):
+                continue
+            for key, values in group_data.items():
+                if key == 'idx':
+                    continue
+                # Find the corresponding variable or expression
+                if key in self.vars:
+                    var = self.vars[key]
+                    # Assign values to the variable
+                    try:
+                        var.v = np.array(values)
+                    except Exception as e:
+                        print(f"values.shape: {np.array(values).shape}")
+                        logger.warning(f"Failed to assign values to var '{key}': {e}")
+                elif key in self.exprs:
+                    continue
+                elif key in self.exprcs:
+                    exprc = self.exprcs[key]
+                    # Assign values to the expression calculation
+                    try:
+                        exprc.v = np.array(values)
+                    except Exception as e:
+                        print(f"values.shape: {np.array(values).shape}")
+                        logger.warning(f"Failed to assign values to exprc '{key}': {e}")
+        logger.info(f"Loaded results from {path}")
+        return True
+
+    def export_json(self, path=None):
+        """
+        Export scheduling results to a json file.
+
+        Parameters
+        ----------
+        path : str, optional
+            Path of the json file to export.
+
+        Returns
+        -------
+        str
+            The exported json file name
+        """
+        if not self.converged:
+            logger.warning("Routine did not converge, aborting export.")
+            return None
+
+        path, file_name = get_export_path(self.system, self.class_name,
+                                          path=path, fmt='json')
+
+        data_dict = dict()
+
+        group_data(self, data_dict, self.vars, 'v')
+        group_data(self, data_dict, self.exprs, 'v')
+        group_data(self, data_dict, self.exprcs, 'v')
+
+        with open(path, 'w') as f:
+            json.dump(data_dict, f, indent=4,
+                      default=lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
+
+        return file_name
 
     def export_csv(self, path=None):
         """
@@ -1022,3 +1106,35 @@ def collect_data(rtn: RoutineBase, data_dict: Dict, items: Dict, attr: str):
             logger.debug(f"Error with collecting data for '{key}': {e}")
             data_v = [np.nan] * len(idx_v)
         data_dict.update(OrderedDict(zip([f'{key} {dev}' for dev in idx_v], data_v)))
+
+
+def group_data(rtn: RoutineBase, data_dict: Dict, items: Dict, attr: str):
+    """
+    Collect data for export from grouped items.
+
+    Parameters
+    ----------
+    rtn : ams.routines.routine.RoutineBase
+        The routine to collect data from.
+    data_dict : OrderedDict
+        The data dictionary to populate.
+    items : dict
+        Dictionary of items to collect data from.
+    attr : str
+        Attribute to collect data for.
+    """
+    for key, item in items.items():
+        if item.owner is None:
+            continue
+        if item.owner.class_name not in data_dict.keys():
+            idx_v = item.get_all_idxes()
+            data_dict[item.owner.class_name] = dict(idx=idx_v)
+        else:
+            idx_v = data_dict[item.owner.class_name]['idx']
+        try:
+            data_v = rtn.get(src=key, attr=attr, idx=idx_v,
+                             horizon=rtn.timeslot.v if hasattr(rtn, 'timeslot') else None)
+        except Exception as e:
+            logger.warning(f"Error with collecting data for '{key}': {e}")
+            data_v = [np.nan] * item.owner.n
+        data_dict[item.owner.class_name][key] = data_v

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -1117,7 +1117,7 @@ def group_data(rtn: RoutineBase, data_dict: Dict, items: Dict, attr: str):
     ----------
     rtn : ams.routines.routine.RoutineBase
         The routine to collect data from.
-    data_dict : OrderedDict
+    data_dict : Dict
         The data dictionary to populate.
     items : dict
         Dictionary of items to collect data from.

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -12,7 +12,10 @@ v1.0
 v1.0.13 (2025-xx-xx)
 ----------------------
 
-- Add functionality to save and load matrices from files
+- Add methods ``export_npz``, ``load_npz``, ``load_csv`` in ``MatProcessor``
+  to save and load matrices from files
+- Add methods ``export_json``, ``load_json`` in ``RoutineBase``
+  to save and load routine results from JSON files
 
 v1.0.12 (2025-05-29)
 ----------------------

--- a/tests/test_export_json.py
+++ b/tests/test_export_json.py
@@ -35,7 +35,8 @@ class TestExportJSON(unittest.TestCase):
         Test export DCOPF to JSON.
         """
         self.ss.DCOPF.run(solver='CLARABEL')
-        self.ss.DCOPF.export_json()
+        exported_filename = self.ss.DCOPF.export_json()
+        self.assertEqual(exported_filename, self.expected_json_DCOPF)
         self.assertTrue(os.path.exists(self.expected_json_DCOPF))
 
         with open(self.expected_json_DCOPF, 'r') as json_file:

--- a/tests/test_export_json.py
+++ b/tests/test_export_json.py
@@ -1,0 +1,109 @@
+"""
+Test routine export to JSON.
+"""
+import unittest
+import os
+import json
+
+import numpy as np
+
+import ams
+
+
+class TestExportJSON(unittest.TestCase):
+    """
+    Tests for Routine export to JSON.
+    """
+
+    def setUp(self) -> None:
+        self.ss = ams.main.load(
+            ams.get_case("5bus/pjm5bus_demo.json"),
+            default_config=True,
+            no_output=True,
+        )
+        self.expected_json_DCOPF = 'pjm5bus_demo_DCOPF.json'
+        self.expected_json_ED = 'pjm5bus_demo_ED.json'
+
+    def test_no_export(self):
+        """
+        Test no export when routine is not converged.
+        """
+        self.assertIsNone(self.ss.DCOPF.export_json())
+
+    def test_export_DCOPF(self):
+        """
+        Test export DCOPF to JSON.
+        """
+        self.ss.DCOPF.run(solver='CLARABEL')
+        self.ss.DCOPF.export_json()
+        self.assertTrue(os.path.exists(self.expected_json_DCOPF))
+
+        with open(self.expected_json_DCOPF, 'r') as json_file:
+            data = json.load(json_file)
+
+        self.assertIn('StaticGen', data)
+        self.assertIn('pg', data['StaticGen'])
+        self.assertIn('pmaxe', data['StaticGen'])
+        self.assertIn('Line', data)
+        self.assertIn('mu1', data['Line'])
+
+    def test_load_DCOPF(self):
+        """
+        Test loading DCOPF from JSON.
+        """
+        ss = ams.main.load(
+            ams.get_case("5bus/pjm5bus_demo.json"),
+            default_config=True,
+            no_output=True,
+        )
+        ss.DCOPF.init()
+        ss.DCOPF.load_json(self.expected_json_DCOPF)
+
+        self.assertIsNotNone(ss.DCOPF.pg.v)
+        self.assertIsNotNone(ss.DCOPF.plfub.v)
+        self.assertIsNotNone(ss.DCOPF.pmaxe.v)
+        self.assertIsNotNone(ss.DCOPF.mu1.v)
+
+        os.remove(self.expected_json_DCOPF)
+
+    def test_export_ED(self):
+        """
+        Test export ED to JSON.
+        """
+        self.ss.ED.run(solver='CLARABEL')
+        self.ss.ED.export_json()
+        self.assertTrue(os.path.exists(self.expected_json_ED))
+
+        with open(self.expected_json_ED, 'r') as json_file:
+            data = json.load(json_file)
+
+        self.assertIn('StaticGen', data)
+        self.assertIn('pg', data['StaticGen'])
+        self.assertIn('pmaxe', data['StaticGen'])
+        self.assertIn('Line', data)
+        self.assertIn('mu1', data['Line'])
+
+    def test_load_ED(self):
+        """
+        Test loading ED from JSON.
+        """
+        ss = ams.main.load(
+            ams.get_case("5bus/pjm5bus_demo.json"),
+            default_config=True,
+            no_output=True,
+        )
+        # NOTE: here we didn't init the ED to test if load_json
+        # works without prior initialization
+        ss.ED.load_json(self.expected_json_ED)
+
+        self.assertIsNotNone(ss.ED.pg.v)
+        np.testing.assert_array_equal(ss.ED.pg.v.shape,
+                                      (ss.StaticGen.n, ss.EDTSlot.n))
+        self.assertIsNotNone(ss.ED.pmaxe.v)
+        np.testing.assert_array_equal(ss.ED.pmaxe.v.shape,
+                                      (ss.StaticGen.n, ss.EDTSlot.n))
+        self.assertIsNotNone(ss.ED.mu1.v)
+        np.testing.assert_array_equal(ss.ED.mu1.v.shape,
+                                      (ss.Line.n, ss.EDTSlot.n))
+
+        os.remove(self.expected_json_ED)


### PR DESCRIPTION
## **CodeAnt-AI Description**
- Introduced `export_json` and `load_json` methods to `RoutineBase`, enabling export and import of routine results in JSON format for improved data portability and reproducibility.
- Added a new helper function `group_data` to facilitate structured data collection for JSON export.
- Implemented comprehensive unit tests for JSON export/import, covering both DCOPF and ED routines, including validation of data integrity and handling of edge cases.
- Enhanced `ExpressionCalc` with a setter for the `v` property, allowing direct value assignment with robust error checking.
- Updated the release notes to document the new JSON IO features and clarify related matrix IO enhancements.

This PR adds robust JSON export and import capabilities to routine results, making it easier to save, share, and reload optimization outcomes. Comprehensive tests ensure reliability, and documentation updates inform users of the new features.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routine.py</strong><dd><code>Add JSON export and import functionality to RoutineBase</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ams/routines/routine.py
<li>Added <code>export_json</code> and <code>load_json</code> methods to <code>RoutineBase</code> for exporting <br>and importing routine results in JSON format.<br> <li> Introduced a new helper function <code>group_data</code> for collecting grouped <br>data for JSON export.<br> <li> Enhanced error handling and logging for JSON IO operations.<br>


</details>


  </td>
  <td><a href="https://github.com/CURENT/ams/pull/182/files#diff-b2843c5f04430266208ca23ef46f14cd72ce41e31b3a41c85e2d7c3cb382b2ec">+119/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>exprcalc.py</strong><dd><code>Add value setter to ExpressionCalc for assignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ams/opt/exprcalc.py
<li>Added a setter for the <code>v</code> property in <code>ExpressionCalc</code> to allow direct <br>assignment of values.<br> <li> Improved error handling for type and evaluation state when setting <br>values.<br>


</details>


  </td>
  <td><a href="https://github.com/CURENT/ams/pull/182/files#diff-bc396a9f4ecc79404ea95e456cbc140a3d77505e0e8bd5c382171b1801893b99">+11/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_export_json.py</strong><dd><code>Add tests for RoutineBase JSON export and import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_export_json.py
<li>Added a new test suite for JSON export and import of routine results.<br> <li> Tests cover exporting and loading for both DCOPF and ED routines, <br>including shape and content validation.<br> <li> Ensures correct behavior when routines are not converged and when <br>loading without prior initialization.<br>


</details>


  </td>
  <td><a href="https://github.com/CURENT/ams/pull/182/files#diff-e8915ce724c36df04e23ae2ba78ae60ae5c48d09fff48d811b14da40391d185d">+109/-0</a>&nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-notes.rst</strong><dd><code>Update release notes for RoutineBase JSON IO features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/source/release-notes.rst
<li>Updated release notes to document new JSON export and import features <br>in <code>RoutineBase</code>.<br> <li> Clarified and expanded notes on matrix IO features in <code>MatProcessor</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/CURENT/ams/pull/182/files#diff-8df47600973a17d4d1effab25f37bcd2bb478c107a0255f6b2b06bdf02a1d5e9">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
