### PR TITLE
refactor(step-1.3): migrate confirm_overwrite to ams.utils.paths; fix set_status FutureWarning

### DIFF
--- a/ams/interface.py
+++ b/ams/interface.py
@@ -725,7 +725,13 @@ class Dynamic:
 
             # --- other scenarios ---
             if _dest_check(mname=mname_ads, pname=pname_ads, idx=idx_ads, adsys=sa):
-                mdl_ads.set(src=pname_ads, idx=idx_ads, attr='v', value=var_ams.v)
+                if pname_ads == 'u':
+                    # ANDES v2.0.0 Model/Group.set(src='u') emits FutureWarning
+                    # on a setup system; use set_status() per-device instead.
+                    for _ii, _vv in zip(idx_ads, var_ams.v):
+                        mdl_ads.set_status(_ii, int(_vv))
+                else:
+                    mdl_ads.set(src=pname_ads, idx=idx_ads, attr='v', value=var_ams.v)
                 logger.warning(f'Send <{vname_ams}> to {mname_ads}.{pname_ads}')
         return True
 

--- a/ams/io/json.py
+++ b/ams/io/json.py
@@ -9,7 +9,7 @@ import logging
 from collections import OrderedDict
 
 from andes.io.json import (testlines, read)  # NOQA
-from andes.utils.paths import confirm_overwrite
+from ams.utils.paths import confirm_overwrite
 
 from ams.shared import pd
 from ams.shared import summary_row, summary_name, model2df

--- a/ams/io/matpower.py
+++ b/ams/io/matpower.py
@@ -6,7 +6,7 @@ import re
 import numpy as np
 
 from andes.io import read_file_like
-from andes.io.xlsx import confirm_overwrite
+from ams.utils.paths import confirm_overwrite
 from ams.utils.func import deg2rad, rad2deg
 
 from ams import __version__ as version

--- a/ams/io/psse.py
+++ b/ams/io/psse.py
@@ -5,7 +5,7 @@ This module is the existing module in ``andes.io.psse``.
 
 from andes.io.psse import testlines  # NOQA
 from andes.io.psse import read as ad_read
-from andes.io.xlsx import confirm_overwrite
+from ams.utils.paths import confirm_overwrite
 import pandas as pd
 from ams.utils.func import rad2deg
 


### PR DESCRIPTION
## Summary

Two deferred items from PR #209 resolved:

1. **confirm_overwrite migration** — `ams/io/psse.py`, `ams/io/matpower.py`, and `ams/io/json.py` imported `confirm_overwrite` from `andes.io.xlsx` or `andes.utils.paths`. All three now use `ams.utils.paths.confirm_overwrite` (already present with identical semantics). ANDES import count: 49 → 46.

2. **set_status FutureWarning** — `Dynamic.send()` in `ams/interface.py` called `mdl_ads.set(src='u', attr='v', …)` on a setup ANDES system. ANDES v2.0.0 emits a `FutureWarning` on this path and routes it to `set_status()` anyway. Fixed by detecting `pname_ads == 'u'` and calling `mdl_ads.set_status(ii, int(vv))` per-device directly.

## Design

See `ams/.claude/designs/step_1_3.md` for full analysis (ANDES v2.0.0 `Model.set` / `Group.set` signature, attack surface, risk table).

## Test plan

- [ ] All 309 tests pass (`pytest tests/ -v`)
- [ ] `flake8 ams/ --max-line-length=120 --exclude=ams/thirdparty` clean
- [ ] ANDES import count = 46 (`grep -rn "^from andes\|^import andes" ams/ --include="*.py" | wc -l`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)