### PR TITLE
Replace andes.io.dump re-export with AMS-owned dispatcher

### DIFF
--- a/ams/io/__init__.py
+++ b/ams/io/__init__.py
@@ -134,7 +134,7 @@ def parse(system):
     return True
 
 
-def dump(system, output_format, full_path=None, overwrite=False, **kwargs):
+def dump(system, output_format, full_path=None, overwrite=None, **kwargs):
     """
     Dump the AMS system data into the requested output format.
 
@@ -142,13 +142,16 @@ def dump(system, output_format, full_path=None, overwrite=False, **kwargs):
     ----------
     system
         System object.
-    output_format : str or bool or None
-        Output format name. ``None`` or ``True`` defaults to ``'xlsx'``.
+    output_format : str
+        Output format name (``'xlsx'`` or ``'json'``). As a convenience,
+        ``None`` or ``True`` is treated as ``'xlsx'``.
     full_path : str, optional
         Full path for the output file. Defaults to
         ``<output_path>/<case_name>.<ext>``.
-    overwrite : bool, optional
-        Overwrite an existing file without prompting.
+    overwrite : bool or None, optional
+        ``None`` (default) prompts interactively when the target exists;
+        ``True`` overwrites without prompting; ``False`` refuses to
+        overwrite. Matches ``ams.io.xlsx.write`` / ``ams.io.json.write``.
     **kwargs
         Forwarded to the per-format writer. ``add_book`` is xlsx-only and
         is dropped for json.

--- a/ams/io/__init__.py
+++ b/ams/io/__init__.py
@@ -8,11 +8,10 @@ import logging
 import os
 
 from ams.utils.misc import elapsed
-from andes.io import dump  # NOQA
 
 from ams.io import xlsx, psse, matpower, pypower, json   # NOQA
 
-__all__ = ['guess', 'parse', 'input_formats', 'output_formats']
+__all__ = ['guess', 'parse', 'dump', 'input_formats', 'output_formats']
 
 logger = logging.getLogger(__name__)
 
@@ -133,3 +132,57 @@ def parse(system):
         logger.info('Addfile parsed in %s.', s)
 
     return True
+
+
+def dump(system, output_format, full_path=None, overwrite=False, **kwargs):
+    """
+    Dump the AMS system data into the requested output format.
+
+    Parameters
+    ----------
+    system
+        System object.
+    output_format : str or bool or None
+        Output format name. ``None`` or ``True`` defaults to ``'xlsx'``.
+    full_path : str, optional
+        Full path for the output file. Defaults to
+        ``<output_path>/<case_name>.<ext>``.
+    overwrite : bool, optional
+        Overwrite an existing file without prompting.
+    **kwargs
+        Forwarded to the per-format writer. ``add_book`` is xlsx-only and
+        is dropped for json.
+
+    Returns
+    -------
+    bool
+        True if successful; False otherwise.
+    """
+    if output_format is None or output_format is True:
+        output_format = 'xlsx'
+
+    if output_format not in output_formats:
+        logger.error("Dump format <%s> not supported.", output_format)
+        return False
+
+    ext = output_formats[output_format][0]
+    if full_path is not None:
+        system.files.dump = full_path
+    else:
+        system.files.dump = os.path.join(system.files.output_path,
+                                         system.files.name + '.' + ext)
+
+    t, _ = elapsed()
+    if output_format == 'xlsx':
+        ret = xlsx.write(system, system.files.dump, overwrite=overwrite, **kwargs)
+    elif output_format == 'json':
+        # ``add_book`` is xlsx-only; ams.io.json.write has no **kwargs, so strip it.
+        json_kwargs = {k: v for k, v in kwargs.items() if k != 'add_book'}
+        ret = json.write(system, system.files.dump, overwrite=overwrite, **json_kwargs)
+    _, s = elapsed(t)
+
+    if ret:
+        logger.info('Format conversion completed in %s.', s)
+        return True
+    logger.error('Format conversion failed.')
+    return False

--- a/ams/system.py
+++ b/ams/system.py
@@ -37,22 +37,6 @@ from ams.io.psse import write_raw
 logger = logging.getLogger(__name__)
 
 
-class _ConfigRuntimeStub:
-    """
-    Minimal stub satisfying the ANDES v2.0.0 ``SystemConfigRuntime`` surface
-    reached via ``ams.run(..., convert=...)``. That path re-exports
-    ``andes.io.dump``, which routes into ANDES's json/xlsx writers; those
-    call ``system.config_runtime.collect_config_rows()`` during dump.
-    AMS does not persist per-system config rows, so return an empty list.
-
-    Defined at module scope so System instances remain picklable for
-    multiprocessing.Pool.
-    """
-
-    def collect_config_rows(self):
-        return []
-
-
 class System:
     """
     Base system class, revised from `andes.system.System`.
@@ -185,11 +169,6 @@ class System:
                       divide=self.config.np_divide,
                       invalid=self.config.np_invalid,
                       )
-
-        # ANDES v2.0.0 json/xlsx writers (reached via ``ams.run(..., convert=...)``
-        # re-exporting ``andes.io.dump``) call ``system.config_runtime.collect_config_rows()``.
-        # AMS does not persist per-system config rows; provide a minimal stub.
-        self.config_runtime = _ConfigRuntimeStub()
 
         # TODO: revise the following attributes, it seems that these are not used in AMS
         self._getters = dict(f=list(), g=list(), x=list(), y=list())


### PR DESCRIPTION
## Summary

- `ams/io/__init__.py` gains a `dump()` function that dispatches directly to `ams.io.xlsx.write` / `ams.io.json.write`, replacing the `from andes.io import dump` re-export. The json branch filters the xlsx-only `add_book` kwarg.
- With nothing in AMS still reaching `system.config_runtime`, `_ConfigRuntimeStub` and its assignment in `ams/system.py` are removed (closes the Step 1.3 follow-up carried from #213).
- ANDES import count: 44 → 43.

## Test plan

- [x] Full pytest suite: 309/309 pass.
- [x] `tests/test_case.py::TestIEEE14RAW::test_ieee14_raw_convert` (default-format xlsx path).
- [x] `tests/test_case.py::TestIEEE14RAW::test_ieee14_raw2json_convert` (convert + round-trip).
- [x] `flake8 ams/ --max-line-length=120` clean.
- [x] `grep -rn config_runtime ams/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)