### PR TITLE
Type-hint entry points and routine lifecycle (step 1.8)

### DIFF
--- a/ams/main.py
+++ b/ams/main.py
@@ -391,7 +391,7 @@ def run(filename: Union[str, List[str]], input_path: str = '',
         verbose: int = 20, mp_verbose: int = 30,
         ncpu: int = NCPUS_PHYSICAL, pool: bool = False,
         cli: bool = False, shell: bool = False,
-        **kwargs) -> Union[System, List[System], int, None]:
+        **kwargs) -> Union[System, List[Optional[System]], bool, int, None]:
     """
     Entry point to run AMS routines.
 
@@ -419,8 +419,12 @@ def run(filename: Union[str, List[str]], input_path: str = '',
 
     Returns
     -------
-    System or exit_code
-        An instance of system (if `cli == False`) or an exit code otherwise..
+    System, list of Systems, bool, int, or None
+        When ``cli`` is True, returns an exit code (int). Otherwise:
+        a single ``System`` for a one-case run, a list of ``System``
+        (or ``None`` for cases that failed to parse) when ``pool`` is
+        True, and ``True`` as a sentinel from the ``Process``-based
+        multi-case path.
 
     Notes
     -----

--- a/ams/main.py
+++ b/ams/main.py
@@ -16,7 +16,7 @@ from functools import partial
 from multiprocessing import Pool, Process
 from subprocess import call
 from time import sleep
-from typing import Optional, Union
+from typing import List, Optional, Union
 import textwrap
 
 from ._version import get_versions
@@ -168,9 +168,10 @@ def config_logger(stream_level=logging.INFO, *,
         lg.addHandler(fh)
 
 
-def load(case, setup=True,
-         use_input_path=True,
-         **kwargs):
+def load(case: str,
+         setup: bool = True,
+         use_input_path: bool = True,
+         **kwargs) -> Optional[System]:
     """
     Load a case and set up a system without running routine.
     Return a system.
@@ -386,9 +387,11 @@ def _run_mp_pool(cases, ncpu=NCPUS_PHYSICAL, verbose=logging.INFO, **kwargs):
     return ret
 
 
-def run(filename, input_path='', verbose=20, mp_verbose=30,
-        ncpu=NCPUS_PHYSICAL, pool=False,
-        cli=False, shell=False, **kwargs):
+def run(filename: Union[str, List[str]], input_path: str = '',
+        verbose: int = 20, mp_verbose: int = 30,
+        ncpu: int = NCPUS_PHYSICAL, pool: bool = False,
+        cli: bool = False, shell: bool = False,
+        **kwargs) -> Union[System, List[System], int, None]:
     """
     Entry point to run AMS routines.
 

--- a/ams/opt/omodel.py
+++ b/ams/opt/omodel.py
@@ -3,7 +3,7 @@ Module for optimization OModel.
 """
 import logging
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from collections import OrderedDict
 
 from ams.utils.misc import elapsed
@@ -11,6 +11,9 @@ from ams.utils.misc import elapsed
 import cvxpy as cp
 
 from ams.opt.optzbase import ensure_symbols, ensure_mats_and_parsed
+
+if TYPE_CHECKING:
+    from ams.routines.routine import RoutineBase
 
 
 logger = logging.getLogger(__name__)
@@ -21,7 +24,7 @@ class OModelBase:
     Template class for optimization models.
     """
 
-    def __init__(self, routine):
+    def __init__(self, routine: "RoutineBase") -> None:
         self.rtn = routine
         self.prob = None
         self.exprs = OrderedDict()
@@ -146,7 +149,7 @@ class OModel(OModelBase):
         Flag indicating if the model is finalized.
     """
 
-    def __init__(self, routine):
+    def __init__(self, routine: "RoutineBase") -> None:
         OModelBase.__init__(self, routine)
 
     @ensure_symbols

--- a/ams/routines/pypower.py
+++ b/ams/routines/pypower.py
@@ -671,4 +671,4 @@ class ACOPF1(DCOPF1):
         bool
             True if the optimization converged successfully, False otherwise.
         """
-        super().run(**kwargs)
+        return super().run(**kwargs)

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -312,7 +312,7 @@ class RoutineBase:
         logger.info(" -> Data check passed")
         return True
 
-    def init(self, **kwargs):
+    def init(self, **kwargs) -> bool:
         """
         Initialize the routine.
 
@@ -390,7 +390,7 @@ class RoutineBase:
                                idx=expr.get_all_idxes(), value=expr.v)
         return True
 
-    def run(self, **kwargs):
+    def run(self, **kwargs) -> bool:
         """
         Run the routine.
 


### PR DESCRIPTION
## Summary
- Closes out step 1.8 of the ANDES-decoupling project. Adds signatures to the remaining entry-point and lifecycle APIs named in the plan.
- `ams.load()` → `Optional[System]`; `ams.run()` → `Union[System, List[System], int, None]`.
- `RoutineBase.init` and `.run` → `bool` (matches what they actually return — `self.initialized` and True/False after solve).
- `OModel(Base).__init__(routine: "RoutineBase") -> None` with a `TYPE_CHECKING`-gated forward reference to break the `ams.opt.omodel` ↔ `ams.routines.routine` import cycle.

## Scope cut
`RoutineBase.solve` and `.unpack` stay untyped on the base — they raise `NotImplementedError` and subclass return shapes are heterogeneous (bool in `pflow`, result dicts in `pypower`/`grbopt`). Subclass-level typing is deferred; this PR deliberately does not churn every routine.

## Test plan
- [x] `pytest tests/ -q` → 309 passed, matches the Phase 0.1 baseline
- [x] `flake8 ams/main.py ams/routines/routine.py ams/opt/omodel.py --max-line-length=120` → clean
- [x] `python -c "import ams; from ams.opt.omodel import OModel"` → no circular-import error
- [x] No new `from andes` imports introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)