### PR TITLE
Scaffold ams.bench subpackage (step 2.4 M1)

### DIFF
--- a/ams/bench/__init__.py
+++ b/ams/bench/__init__.py
@@ -1,0 +1,16 @@
+"""AMS performance benchmark suite.
+
+Homegrown, zero non-stdlib deps. Runnable via ``python -m ams.bench``.
+See ``bench/README.md`` at the repo root for usage and submission format.
+"""
+from ams.bench.env import capture_env
+from ams.bench.harness import Measurement, measure
+from ams.bench.schema import SCHEMA_VERSION, build_report
+
+__all__ = [
+    "Measurement",
+    "SCHEMA_VERSION",
+    "build_report",
+    "capture_env",
+    "measure",
+]

--- a/ams/bench/__main__.py
+++ b/ams/bench/__main__.py
@@ -1,0 +1,62 @@
+"""CLI entry point: ``python -m ams.bench``.
+
+M1 scaffold — emits a report with the environment captured and an
+empty ``results`` list. M2 wires in the Tier A benchmarks.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Sequence
+
+from ams.bench.env import capture_env
+from ams.bench.harness import Measurement
+from ams.bench.schema import build_report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m ams.bench",
+        description="Run the AMS performance benchmark suite.",
+    )
+    parser.add_argument(
+        "--suite",
+        default="tier_a",
+        help="Suite to run (default: tier_a).",
+    )
+    parser.add_argument(
+        "--output",
+        default="-",
+        help="Output path for the JSON report, or '-' for stdout (default).",
+    )
+    parser.add_argument(
+        "--reps",
+        type=int,
+        default=5,
+        help="Measured reps per benchmark (default: 5).",
+    )
+    parser.add_argument(
+        "--warmup-reps",
+        type=int,
+        default=1,
+        help="Warmup reps, discarded (default: 1).",
+    )
+    args = parser.parse_args(argv)
+
+    env = capture_env()
+    results: list[Measurement] = []  # M2 populates this.
+
+    report = build_report(suite=args.suite, environment=env, results=results)
+    payload = json.dumps(report, indent=2)
+
+    if args.output == "-":
+        print(payload)
+    else:
+        with open(args.output, "w") as fh:
+            fh.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ams/bench/env.py
+++ b/ams/bench/env.py
@@ -1,0 +1,45 @@
+"""Capture runtime environment for a benchmark run.
+
+Adapted from the removed ``ams/benchmarks.py``. ``pandapower`` is not
+probed by default (step 2.4 scope decision, 2026-04-22); pass it
+explicitly if needed.
+"""
+from __future__ import annotations
+
+import datetime
+import importlib.metadata as importlib_metadata
+import os
+import platform
+import sys
+from typing import Iterable
+
+_DEFAULT_TOOLS: tuple[str, ...] = (
+    "ltbams",
+    "andes",
+    "cvxpy",
+    "gurobipy",
+    "mosek",
+    "piqp",
+    "numba",
+)
+
+
+def capture_env(tools: Iterable[str] | None = None) -> dict:
+    """Return a JSON-serializable dict describing the runtime stack."""
+    tool_list = tuple(tools) if tools is not None else _DEFAULT_TOOLS
+
+    versions: dict[str, str] = {}
+    for tool in tool_list:
+        try:
+            versions[tool] = importlib_metadata.version(tool)
+        except importlib_metadata.PackageNotFoundError:
+            versions[tool] = "not installed"
+
+    return {
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "tool_versions": versions,
+    }

--- a/ams/bench/harness.py
+++ b/ams/bench/harness.py
@@ -1,0 +1,98 @@
+"""Timer core for the AMS bench suite.
+
+Zero non-stdlib deps. ``measure()`` wraps a callable with a configurable
+warmup + repeat count and returns a ``Measurement`` summary. Exceptions
+are caught per-rep so a single broken benchmark never aborts the suite.
+"""
+from __future__ import annotations
+
+import logging
+import statistics
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Measurement:
+    """Summary of one benchmarked callable.
+
+    ``raw_s`` holds the per-rep wall-clock seconds; summary fields are
+    ``None`` when the benchmark errored before producing any reps.
+    """
+
+    name: str
+    group: str
+    reps: int
+    warmup_reps: int
+    mean_s: float | None
+    stdev_s: float | None
+    min_s: float | None
+    max_s: float | None
+    raw_s: list[float]
+    error: str | None = None
+
+
+def measure(
+    fn: Callable[[], float | None],
+    *,
+    name: str,
+    group: str,
+    reps: int = 5,
+    warmup_reps: int = 1,
+) -> Measurement:
+    """Run ``fn`` ``warmup_reps`` times (discarded) then ``reps`` times measured.
+
+    ``fn`` can self-time by returning a float (seconds), or return ``None``
+    and let this helper wrap the call in ``perf_counter``. Self-timing lets
+    benchmarks exclude setup/teardown from the measured window.
+
+    On any exception, logs a warning and returns a ``Measurement`` with
+    ``error`` set and ``None`` summary stats; the caller continues.
+    """
+    try:
+        for _ in range(warmup_reps):
+            fn()
+    except Exception as exc:
+        logger.warning("bench %s/%s: warmup failed: %s", group, name, exc)
+        return _failed(name, group, reps, warmup_reps, str(exc))
+
+    raw: list[float] = []
+    for _ in range(reps):
+        try:
+            t0 = time.perf_counter()
+            out = fn()
+            dt = time.perf_counter() - t0
+            raw.append(float(out) if isinstance(out, (int, float)) else dt)
+        except Exception as exc:
+            logger.warning("bench %s/%s: rep failed: %s", group, name, exc)
+            return _failed(name, group, reps, warmup_reps, str(exc))
+
+    return Measurement(
+        name=name,
+        group=group,
+        reps=reps,
+        warmup_reps=warmup_reps,
+        mean_s=statistics.fmean(raw),
+        stdev_s=statistics.stdev(raw) if len(raw) > 1 else 0.0,
+        min_s=min(raw),
+        max_s=max(raw),
+        raw_s=raw,
+    )
+
+
+def _failed(name: str, group: str, reps: int, warmup_reps: int, msg: str) -> Measurement:
+    return Measurement(
+        name=name,
+        group=group,
+        reps=reps,
+        warmup_reps=warmup_reps,
+        mean_s=None,
+        stdev_s=None,
+        min_s=None,
+        max_s=None,
+        raw_s=[],
+        error=msg,
+    )

--- a/ams/bench/harness.py
+++ b/ams/bench/harness.py
@@ -36,7 +36,7 @@ class Measurement:
 
 
 def measure(
-    fn: Callable[[], float | None],
+    fn: Callable[[], float | int | None],
     *,
     name: str,
     group: str,
@@ -45,12 +45,14 @@ def measure(
 ) -> Measurement:
     """Run ``fn`` ``warmup_reps`` times (discarded) then ``reps`` times measured.
 
-    ``fn`` can self-time by returning a float (seconds), or return ``None``
+    ``fn`` can self-time by returning a number (seconds), or return ``None``
     and let this helper wrap the call in ``perf_counter``. Self-timing lets
     benchmarks exclude setup/teardown from the measured window.
 
-    On any exception, logs a warning and returns a ``Measurement`` with
-    ``error`` set and ``None`` summary stats; the caller continues.
+    On a rep exception, logs a warning, stops iterating, and returns a
+    ``Measurement`` built from whatever successful reps completed — with
+    ``error`` set to the exception string so partial progress isn't hidden.
+    Only when *no* rep succeeds are summary stats ``None``.
     """
     try:
         for _ in range(warmup_reps):
@@ -60,6 +62,7 @@ def measure(
         return _failed(name, group, reps, warmup_reps, str(exc))
 
     raw: list[float] = []
+    err: str | None = None
     for _ in range(reps):
         try:
             t0 = time.perf_counter()
@@ -68,7 +71,11 @@ def measure(
             raw.append(float(out) if isinstance(out, (int, float)) else dt)
         except Exception as exc:
             logger.warning("bench %s/%s: rep failed: %s", group, name, exc)
-            return _failed(name, group, reps, warmup_reps, str(exc))
+            err = str(exc)
+            break
+
+    if not raw:
+        return _failed(name, group, reps, warmup_reps, err or "no successful reps")
 
     return Measurement(
         name=name,
@@ -80,6 +87,7 @@ def measure(
         min_s=min(raw),
         max_s=max(raw),
         raw_s=raw,
+        error=err,
     )
 
 

--- a/ams/bench/schema.py
+++ b/ams/bench/schema.py
@@ -1,0 +1,29 @@
+"""Output schema for the AMS bench suite.
+
+The suite emits one JSON document per run. ``SCHEMA_VERSION`` is
+explicit so future consumers (cloud reporter, dashboard) can reject
+incompatible runs instead of silently mis-parsing them.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Iterable
+
+from ams.bench.harness import Measurement
+
+SCHEMA_VERSION = 1
+
+
+def build_report(
+    *,
+    suite: str,
+    environment: dict,
+    results: Iterable[Measurement],
+) -> dict:
+    """Assemble a report dict ready for ``json.dumps()``."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "suite": suite,
+        "environment": environment,
+        "results": [asdict(m) for m in results],
+    }

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,23 @@
+# AMS benchmark suite
+
+This directory holds benchmark baselines and user-submitted reports
+for the AMS performance suite. The suite's **code** lives in
+`ams/bench/` and ships in the wheel; this directory holds **data**
+and is intentionally excluded from the wheel.
+
+## Running a benchmark
+
+```bash
+python -m ams.bench --suite tier_a --output bench/baselines/YYYY-MM-DD_<branch>.json
+```
+
+Full usage and interpretation docs land with milestone M3 of step 2.4.
+
+## Layout
+
+```
+bench/
+├── README.md        # this file
+├── baselines/       # maintainer-captured reference runs
+└── user_reports/    # optional: user-submitted benchmark outputs
+```

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,0 +1,27 @@
+"""Smoke test for the AMS benchmark suite scaffold.
+
+Keeps ``ams/bench/`` honest: if a refactor breaks the CLI entry point
+or the output schema, this test fails loudly. Full perf runs are not
+exercised here — that's the suite's own job.
+"""
+import json
+import subprocess
+import sys
+
+
+def test_bench_cli_emits_valid_schema_v1_report():
+    """``python -m ams.bench`` emits a schema-v1 JSON with env captured."""
+    out = subprocess.check_output(
+        [sys.executable, "-m", "ams.bench", "--suite", "tier_a"],
+        text=True,
+    )
+    report = json.loads(out)
+
+    assert report["schema_version"] == 1
+    assert report["suite"] == "tier_a"
+    assert isinstance(report["results"], list)
+
+    env = report["environment"]
+    assert env["python"].startswith("3.")
+    assert "ltbams" in env["tool_versions"]
+    assert "andes" in env["tool_versions"]

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -11,11 +11,14 @@ import sys
 
 def test_bench_cli_emits_valid_schema_v1_report():
     """``python -m ams.bench`` emits a schema-v1 JSON with env captured."""
-    out = subprocess.check_output(
+    result = subprocess.run(
         [sys.executable, "-m", "ams.bench", "--suite", "tier_a"],
+        capture_output=True,
         text=True,
+        check=True,
+        timeout=30,
     )
-    report = json.loads(out)
+    report = json.loads(result.stdout)
 
     assert report["schema_version"] == 1
     assert report["suite"] == "tier_a"


### PR DESCRIPTION
## Summary

Phase 2.4 Milestone 1 of the ANDES-decoupling project — scaffolds the homegrown performance-benchmark suite. Plumbing only; real benchmarks land in M2.

**Design doc** (local knowledge base): `.claude/projects/andes_decoupling/step_2_4.md`

**Decisions driving this PR:**
- Homegrown over pytest-benchmark / asv — maximizes portability for the stated roadmap (cloud migration, standalone-exe). asv stays a clean upgrade path if we ever need commit-by-commit trending.
- Code at `ams/bench/` (ships in wheel), baselines at `repo-root/bench/` (git-tracked, not shipped). Lets `pip install ltbams && python -m ams.bench` work out of the box — supports future user-submitted reports.
- Patterns adapted from the removed `ams/benchmarks.py` (commit `45cd1bc8`, Jan 2025): env capture, exception-safe measurement. That module rotted because it had no CLI, no tests, no invocation story — this scaffold addresses all three from day 1.

## Changes

- `ams/bench/harness.py` — `measure()` with warmup + reps + stdev, `Measurement` dataclass. Per-rep exception catch so one broken benchmark never aborts the whole suite.
- `ams/bench/env.py` — `capture_env()` returns timestamp + Python + platform + CPU count + tool versions (`ltbams`, `andes`, `cvxpy`, `gurobipy`, `mosek`, `piqp`, `numba`). `pandapower` dropped from defaults per 2.4 scope.
- `ams/bench/schema.py` — `SCHEMA_VERSION = 1` + `build_report()`. Explicit versioning so future consumers can reject incompatible runs.
- `ams/bench/__main__.py` — `python -m ams.bench [--suite tier_a] [--output -] [--reps 5] [--warmup-reps 1]`. M1 emits env + empty results; M2 populates.
- `tests/test_bench.py` — subprocess smoke test that runs the CLI and asserts schema v1 shape. ~1s; keeps the scaffold honest without gating real measurement on CI.

Zero non-stdlib deps.

## Sample output

```json
{
  "schema_version": 1,
  "suite": "tier_a",
  "environment": {
    "timestamp": "2026-04-22T18:08:59.413275+00:00",
    "python": "3.12.0",
    "platform": "macOS-26.3.1-arm64-arm-64bit",
    "machine": "arm64",
    "cpu_count": 12,
    "tool_versions": {
      "ltbams": "...",
      "andes": "2.0.0",
      "cvxpy": "1.7.5",
      "gurobipy": "13.0.0",
      "mosek": "not installed",
      "piqp": "0.5.0",
      "numba": "0.61.0"
    }
  },
  "results": []
}
```

## Test plan

- [x] `python -m ams.bench --suite tier_a` — valid schema v1 JSON with env captured.
- [x] `pytest tests/test_bench.py -v` — 1 passed in 1.12s.
- [x] `flake8 ams/bench/ tests/test_bench.py --max-line-length=120` — clean.
- [x] Full suite: 310 passed, 9 warnings, 50.46s (was 309/49.75s; +1 for the new smoke test, +0.7s wall-clock).

## Follow-ups (not in this PR)

- M2: wire case ladder + 5-phase routine init + solve timing (Tier A scope).
- M3: capture first baseline to `bench/baselines/` + user-facing README at `bench/README.md`.
- M4 (optional): co-sim end-to-end benchmark (Tier B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)