### PR TITLE
Wire Tier A benchmarks into ams.bench (step 2.4 M2)

### DIFF
--- a/ams/bench/__init__.py
+++ b/ams/bench/__init__.py
@@ -1,10 +1,12 @@
 """AMS performance benchmark suite.
 
-Homegrown, zero non-stdlib deps. Runnable via ``python -m ams.bench``.
-See ``bench/README.md`` at the repo root for usage and submission format.
+Homegrown, stdlib-only plus ``psutil`` (already an AMS runtime dep).
+Runnable via ``python -m ams.bench``. See ``bench/README.md`` at the
+repo root for usage and submission format.
 """
 from ams.bench.env import capture_env
-from ams.bench.harness import Measurement, measure
+from ams.bench.harness import Measurement, measure, summarize
+from ams.bench.routines import run_smoke, run_tier_a
 from ams.bench.schema import SCHEMA_VERSION, build_report
 
 __all__ = [
@@ -13,4 +15,7 @@ __all__ = [
     "build_report",
     "capture_env",
     "measure",
+    "run_smoke",
+    "run_tier_a",
+    "summarize",
 ]

--- a/ams/bench/__main__.py
+++ b/ams/bench/__main__.py
@@ -1,18 +1,27 @@
 """CLI entry point: ``python -m ams.bench``.
 
-M1 scaffold — emits a report with the environment captured and an
-empty ``results`` list. M2 wires in the Tier A benchmarks.
+Emits a JSON report with the ``environment`` captured and the results
+of the selected ``--suite``. ``tier_a`` is the only suite that
+produces real measurements today; M4 adds Tier B (co-sim, solver
+sweep).
 """
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import sys
 from typing import Sequence
 
 from ams.bench.env import capture_env
 from ams.bench.harness import Measurement
+from ams.bench.routines import run_smoke, run_tier_a
 from ams.bench.schema import build_report
+
+_SUITES = {
+    "smoke": run_smoke,
+    "tier_a": run_tier_a,
+}
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -23,6 +32,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--suite",
         default="tier_a",
+        choices=sorted(_SUITES.keys()),
         help="Suite to run (default: tier_a).",
     )
     parser.add_argument(
@@ -42,10 +52,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=1,
         help="Warmup reps, discarded (default: 1).",
     )
+    parser.add_argument(
+        "--solver",
+        default="CLARABEL",
+        help="Solver to use for routine_solve benchmarks (default: CLARABEL). "
+             "Per-result JSON records the solver used so outputs from different "
+             "runs stay comparable. UC-family routines need a MIP solver and "
+             "are not in Tier A.",
+    )
     args = parser.parse_args(argv)
 
     env = capture_env()
-    results: list[Measurement] = []  # M2 populates this.
+
+    # Some benchmarked routines (notably ACOPF via PYPOWER) print to
+    # stdout while solving. Redirect stdout to stderr during suite
+    # execution so our JSON report on real stdout stays clean.
+    with contextlib.redirect_stdout(sys.stderr):
+        results: list[Measurement] = _SUITES[args.suite](
+            reps=args.reps,
+            warmup_reps=args.warmup_reps,
+            solver=args.solver,
+        )
 
     report = build_report(suite=args.suite, environment=env, results=results)
     payload = json.dumps(report, indent=2)

--- a/ams/bench/cases.py
+++ b/ams/bench/cases.py
@@ -1,0 +1,33 @@
+"""Case ladder for the AMS bench suite.
+
+Each ``CaseSpec.path`` is an ``ams.get_case``-compatible relative
+path. ``ROUTINE_CASES`` holds the subset that ships with the time-series
+data needed for RTED / ED / UC-style routines.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CaseSpec:
+    name: str
+    path: str
+
+
+# Full ladder for the case-load benchmark — spans small to stress scale.
+CASE_LADDER: tuple[CaseSpec, ...] = (
+    CaseSpec("case5", "matpower/case5.m"),
+    CaseSpec("ieee14_uced", "ieee14/ieee14_uced.xlsx"),
+    CaseSpec("ieee39_uced", "ieee39/ieee39_uced.xlsx"),
+    CaseSpec("case300", "matpower/case300.m"),
+    CaseSpec("npcc_uced", "npcc/npcc_uced.xlsx"),
+)
+
+# Cases where routine-level benchmarks run. Restricted to ``*_uced``
+# variants because they ship the time-series / cost data that the
+# scheduling routines expect.
+ROUTINE_CASES: tuple[CaseSpec, ...] = (
+    CaseSpec("ieee14_uced", "ieee14/ieee14_uced.xlsx"),
+    CaseSpec("ieee39_uced", "ieee39/ieee39_uced.xlsx"),
+)

--- a/ams/bench/env.py
+++ b/ams/bench/env.py
@@ -96,7 +96,7 @@ def _cpu_brand() -> str:
             for line in proc_cpuinfo.read_text().splitlines():
                 if line.startswith("model name"):
                     return line.split(":", 1)[1].strip()
-        except OSError:
+        except Exception:  # env capture must never raise
             pass
     # macOS: sysctl
     try:

--- a/ams/bench/env.py
+++ b/ams/bench/env.py
@@ -1,17 +1,22 @@
 """Capture runtime environment for a benchmark run.
 
-Adapted from the removed ``ams/benchmarks.py``. ``pandapower`` is not
-probed by default (step 2.4 scope decision, 2026-04-22); pass it
-explicitly if needed.
+Adapted from the removed ``ams/benchmarks.py`` (commit ``45cd1bc8``).
+``pandapower`` is not probed by default (step 2.4 scope decision,
+2026-04-22); pass it explicitly if needed.
 """
 from __future__ import annotations
 
 import datetime
 import importlib.metadata as importlib_metadata
+import logging
 import os
 import platform
+import subprocess
 import sys
+from pathlib import Path
 from typing import Iterable
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_TOOLS: tuple[str, ...] = (
     "ltbams",
@@ -25,7 +30,14 @@ _DEFAULT_TOOLS: tuple[str, ...] = (
 
 
 def capture_env(tools: Iterable[str] | None = None) -> dict:
-    """Return a JSON-serializable dict describing the runtime stack."""
+    """Return a JSON-serializable dict describing the runtime stack.
+
+    Covers software (Python, tool versions, BLAS backend, conda env),
+    hardware (CPU brand + count, memory total/available), and
+    provenance (git SHA + dirty flag, whether we're running inside
+    pytest). Every field degrades gracefully to ``None`` / ``"unknown"``
+    if it can't be determined — env capture must never raise.
+    """
     tool_list = tuple(tools) if tools is not None else _DEFAULT_TOOLS
 
     versions: dict[str, str] = {}
@@ -35,11 +47,106 @@ def capture_env(tools: Iterable[str] | None = None) -> dict:
         except importlib_metadata.PackageNotFoundError:
             versions[tool] = "not installed"
 
+    mem_total_gb, mem_avail_gb, mem_pct = _memory_snapshot()
+    git_sha, git_dirty = _git_info()
+
     return {
         "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "python": sys.version.split()[0],
         "platform": platform.platform(),
         "machine": platform.machine(),
+        "cpu_brand": _cpu_brand(),
         "cpu_count": os.cpu_count(),
+        "memory_total_gb": mem_total_gb,
+        "memory_available_gb": mem_avail_gb,
+        "memory_percent_used_at_start": mem_pct,
+        "blas_backend": _blas_backend(),
+        "conda_env": os.environ.get("CONDA_DEFAULT_ENV"),
+        "git_commit": git_sha,
+        "git_dirty": git_dirty,
+        "running_under_pytest": "pytest" in sys.modules,
         "tool_versions": versions,
     }
+
+
+def _memory_snapshot() -> tuple[float | None, float | None, float | None]:
+    """Return (total_gb, available_gb, percent_used) via psutil if present."""
+    try:
+        import psutil
+    except ImportError:
+        return None, None, None
+    try:
+        vm = psutil.virtual_memory()
+        return (
+            round(vm.total / 1e9, 2),
+            round(vm.available / 1e9, 2),
+            vm.percent,
+        )
+    except Exception as exc:
+        logger.warning("bench env: psutil.virtual_memory() failed: %s", exc)
+        return None, None, None
+
+
+def _cpu_brand() -> str:
+    """Return a human-readable CPU model name, or ``platform.processor()`` fallback."""
+    # Linux: /proc/cpuinfo
+    proc_cpuinfo = Path("/proc/cpuinfo")
+    if proc_cpuinfo.exists():
+        try:
+            for line in proc_cpuinfo.read_text().splitlines():
+                if line.startswith("model name"):
+                    return line.split(":", 1)[1].strip()
+        except OSError:
+            pass
+    # macOS: sysctl
+    try:
+        out = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        pass
+    # Fallback — Windows usually works here, macOS silicon returns "arm".
+    return platform.processor() or "unknown"
+
+
+def _git_info() -> tuple[str | None, bool | None]:
+    """Return (short sha, dirty flag). Both ``None`` if not in a git repo."""
+    try:
+        sha_res = subprocess.run(
+            ["git", "rev-parse", "--short=10", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if sha_res.returncode != 0 or not sha_res.stdout.strip():
+            return None, None
+        sha = sha_res.stdout.strip()
+
+        dirty_res = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, timeout=5,
+        )
+        dirty = bool(dirty_res.stdout.strip()) if dirty_res.returncode == 0 else None
+        return sha, dirty
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return None, None
+
+
+def _blas_backend() -> str | None:
+    """Summarize numpy's BLAS backend name, or ``None`` if undetectable."""
+    try:
+        import numpy
+    except ImportError:
+        return None
+    try:
+        config = numpy.show_config(mode="dicts")
+    except (TypeError, AttributeError):
+        return None
+    try:
+        deps = config.get("Build Dependencies", {})
+        blas = deps.get("blas") or {}
+        name = blas.get("name")
+        return name or None
+    except Exception:
+        return None

--- a/ams/bench/harness.py
+++ b/ams/bench/harness.py
@@ -3,13 +3,16 @@
 Zero non-stdlib deps. ``measure()`` wraps a callable with a configurable
 warmup + repeat count and returns a ``Measurement`` summary. Exceptions
 are caught per-rep so a single broken benchmark never aborts the suite.
+``summarize()`` builds the same structure from a pre-collected list of
+per-rep timings — useful when one iteration produces multiple dimensions
+(e.g., 5-phase routine-init breakdowns that share one system load).
 """
 from __future__ import annotations
 
 import logging
 import statistics
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable
 
 logger = logging.getLogger(__name__)
@@ -21,6 +24,9 @@ class Measurement:
 
     ``raw_s`` holds the per-rep wall-clock seconds; summary fields are
     ``None`` when the benchmark errored before producing any reps.
+    Structured dimensions (``routine`` / ``case`` / ``solver`` / ``phase``)
+    are optional tags that let downstream consumers (dashboards, cloud
+    reporters) filter without parsing the ``name`` string.
     """
 
     name: str
@@ -33,6 +39,11 @@ class Measurement:
     max_s: float | None
     raw_s: list[float]
     error: str | None = None
+    routine: str | None = None
+    case: str | None = None
+    solver: str | None = None
+    phase: str | None = None
+    metadata: dict = field(default_factory=dict)
 
 
 def measure(
@@ -42,6 +53,11 @@ def measure(
     group: str,
     reps: int = 5,
     warmup_reps: int = 1,
+    routine: str | None = None,
+    case: str | None = None,
+    solver: str | None = None,
+    phase: str | None = None,
+    metadata: dict | None = None,
 ) -> Measurement:
     """Run ``fn`` ``warmup_reps`` times (discarded) then ``reps`` times measured.
 
@@ -74,20 +90,59 @@ def measure(
             err = str(exc)
             break
 
-    if not raw:
-        return _failed(name, group, reps, warmup_reps, err or "no successful reps")
-
-    return Measurement(
+    return summarize(
+        raw,
         name=name,
         group=group,
         reps=reps,
         warmup_reps=warmup_reps,
+        error=err,
+        routine=routine,
+        case=case,
+        solver=solver,
+        phase=phase,
+        metadata=metadata,
+    )
+
+
+def summarize(
+    raw: list[float],
+    *,
+    name: str,
+    group: str,
+    reps: int,
+    warmup_reps: int,
+    error: str | None = None,
+    routine: str | None = None,
+    case: str | None = None,
+    solver: str | None = None,
+    phase: str | None = None,
+    metadata: dict | None = None,
+) -> Measurement:
+    """Build a Measurement from a pre-collected list of per-rep timings.
+
+    Use when you can't fit the work into a single ``fn`` call — e.g., a
+    multi-phase init breakdown where one system load produces five
+    timings, one per phase.
+    """
+    common = dict(
+        name=name, group=group, reps=reps, warmup_reps=warmup_reps,
+        routine=routine, case=case, solver=solver, phase=phase,
+        metadata=metadata or {},
+    )
+    if not raw:
+        return Measurement(
+            mean_s=None, stdev_s=None, min_s=None, max_s=None, raw_s=[],
+            error=error or "no successful reps", **common,
+        )
+    return Measurement(
         mean_s=statistics.fmean(raw),
         stdev_s=statistics.stdev(raw) if len(raw) > 1 else 0.0,
         min_s=min(raw),
         max_s=max(raw),
         raw_s=raw,
-        error=err,
+        error=error,
+        **common,
     )
 
 

--- a/ams/bench/routines.py
+++ b/ams/bench/routines.py
@@ -1,0 +1,245 @@
+"""Per-routine benchmark harness.
+
+Ports the 5-phase init breakdown and solve-timing pattern from the
+removed ``ams/benchmarks.py`` (commit ``45cd1bc8``), adapted to the
+new ``Measurement`` schema (structured ``routine`` / ``case`` /
+``solver`` / ``phase`` dimensions).
+
+Tier A targets LP-family routines with CLARABEL as the default
+solver. UC / UC2 are deferred to Tier B because they're MIPs and
+CLARABEL doesn't do MIP.
+"""
+from __future__ import annotations
+
+import logging
+import time
+
+import ams
+
+from ams.bench.cases import CASE_LADDER, ROUTINE_CASES, CaseSpec
+from ams.bench.harness import Measurement, summarize
+
+logger = logging.getLogger(__name__)
+
+INIT_PHASES: tuple[str, ...] = (
+    "mats", "parse", "evaluate", "finalize", "postinit",
+)
+
+TIER_A_ROUTINES: tuple[str, ...] = ("DCOPF", "RTED", "ED", "ACOPF")
+
+
+def bench_case_load(case: CaseSpec, *, reps: int, warmup_reps: int) -> Measurement:
+    """Time ``ams.load(case)`` over ``reps`` measured iterations."""
+    from ams.bench.harness import measure
+
+    def _load() -> None:
+        ams.load(
+            ams.get_case(case.path),
+            setup=True, no_output=True, default_config=True,
+        )
+
+    return measure(
+        _load,
+        name=f"case_load/{case.name}",
+        group="case_load",
+        reps=reps,
+        warmup_reps=warmup_reps,
+        case=case.name,
+    )
+
+
+def bench_routine_init_phases(
+    case: CaseSpec,
+    routine: str,
+    *,
+    reps: int,
+    warmup_reps: int,
+) -> list[Measurement]:
+    """Measure each of the 5 init phases for ``routine`` on ``case``.
+
+    Each iteration = one fresh ``ams.load`` + one full init sequence.
+    The first ``warmup_reps`` iterations are discarded; remaining reps
+    populate a per-phase raw timings list. Returns one ``Measurement``
+    per phase. On iteration failure, remaining iterations are skipped
+    and the error is recorded on every phase returned.
+    """
+    per_phase_raw: dict[str, list[float]] = {p: [] for p in INIT_PHASES}
+    err: str | None = None
+
+    for i in range(warmup_reps + reps):
+        try:
+            sp = ams.load(
+                ams.get_case(case.path),
+                setup=True, no_output=True, default_config=True,
+            )
+            rtn = sp.routines[routine]
+
+            phase_times = {}
+            t0 = time.perf_counter()
+            sp.mats.build(force=True)
+            phase_times["mats"] = time.perf_counter() - t0
+
+            t0 = time.perf_counter()
+            rtn.om.parse(force=True)
+            phase_times["parse"] = time.perf_counter() - t0
+
+            t0 = time.perf_counter()
+            rtn.om.evaluate(force=True)
+            phase_times["evaluate"] = time.perf_counter() - t0
+
+            t0 = time.perf_counter()
+            rtn.om.finalize(force=True)
+            phase_times["finalize"] = time.perf_counter() - t0
+
+            t0 = time.perf_counter()
+            rtn.init()
+            phase_times["postinit"] = time.perf_counter() - t0
+
+            if i >= warmup_reps:
+                for phase in INIT_PHASES:
+                    per_phase_raw[phase].append(phase_times[phase])
+        except Exception as exc:
+            logger.warning(
+                "bench init-phase %s/%s iter %d failed: %s",
+                routine, case.name, i, exc,
+            )
+            err = str(exc)
+            break
+
+    return [
+        summarize(
+            per_phase_raw[phase],
+            name=f"{routine}/{case.name}/{phase}",
+            group="routine_init_phase",
+            reps=reps,
+            warmup_reps=warmup_reps,
+            error=err,
+            routine=routine,
+            case=case.name,
+            phase=phase,
+        )
+        for phase in INIT_PHASES
+    ]
+
+
+def bench_routine_solve(
+    case: CaseSpec,
+    routine: str,
+    solver: str,
+    *,
+    reps: int,
+    warmup_reps: int,
+) -> Measurement:
+    """Time ``rtn.run(solver=...)`` wall-clock.
+
+    Loads + inits once outside the measured window; each rep calls
+    ``rtn.run(solver=...)``. Setup cost is excluded from the timing
+    so the measurement reflects solver + model evaluation, not I/O.
+    """
+    try:
+        sp = ams.load(
+            ams.get_case(case.path),
+            setup=True, no_output=True, default_config=True,
+        )
+        rtn = sp.routines[routine]
+    except Exception as exc:
+        logger.warning(
+            "bench solve %s/%s/%s: load failed: %s",
+            routine, case.name, solver, exc,
+        )
+        return summarize(
+            [],
+            name=f"{routine}/{case.name}/{solver}",
+            group="routine_solve",
+            reps=reps,
+            warmup_reps=warmup_reps,
+            error=str(exc),
+            routine=routine,
+            case=case.name,
+            solver=solver,
+        )
+
+    raw: list[float] = []
+    err: str | None = None
+    for i in range(warmup_reps + reps):
+        try:
+            t0 = time.perf_counter()
+            rtn.run(solver=solver)
+            dt = time.perf_counter() - t0
+            if i >= warmup_reps:
+                raw.append(dt)
+        except Exception as exc:
+            logger.warning(
+                "bench solve %s/%s/%s iter %d failed: %s",
+                routine, case.name, solver, i, exc,
+            )
+            err = str(exc)
+            break
+
+    return summarize(
+        raw,
+        name=f"{routine}/{case.name}/{solver}",
+        group="routine_solve",
+        reps=reps,
+        warmup_reps=warmup_reps,
+        error=err,
+        routine=routine,
+        case=case.name,
+        solver=solver,
+    )
+
+
+def run_smoke(
+    *,
+    reps: int = 1,
+    warmup_reps: int = 0,
+    solver: str = "CLARABEL",
+) -> list[Measurement]:
+    """Minimal suite (~2 measurements) for CI smoke-testing.
+
+    Not a real perf measurement — just validates the end-to-end CLI +
+    JSON serialization path. Prefer ``run_tier_a`` for actual baselines.
+    """
+    return [
+        bench_case_load(CASE_LADDER[0], reps=reps, warmup_reps=warmup_reps),
+        bench_routine_solve(
+            ROUTINE_CASES[0], "DCOPF", solver,
+            reps=reps, warmup_reps=warmup_reps,
+        ),
+    ]
+
+
+def run_tier_a(
+    *,
+    reps: int = 5,
+    warmup_reps: int = 1,
+    solver: str = "CLARABEL",
+) -> list[Measurement]:
+    """Run the full Tier A suite and return all Measurements.
+
+    Emits ~40 measurements in three groups:
+
+    - ``case_load`` for every entry in ``CASE_LADDER``.
+    - ``routine_init_phase`` = 5 phases × 4 routines × 2 routine
+      cases = 40 (but collected as per-phase Measurements, so each
+      Measurement is one row).
+    - ``routine_solve`` = 4 routines × 2 routine cases = 8.
+    """
+    results: list[Measurement] = []
+
+    for case in CASE_LADDER:
+        results.append(bench_case_load(case, reps=reps, warmup_reps=warmup_reps))
+
+    for case in ROUTINE_CASES:
+        for routine in TIER_A_ROUTINES:
+            results.extend(bench_routine_init_phases(
+                case, routine, reps=reps, warmup_reps=warmup_reps,
+            ))
+
+    for case in ROUTINE_CASES:
+        for routine in TIER_A_ROUTINES:
+            results.append(bench_routine_solve(
+                case, routine, solver, reps=reps, warmup_reps=warmup_reps,
+            ))
+
+    return results

--- a/ams/bench/routines.py
+++ b/ams/bench/routines.py
@@ -22,7 +22,7 @@ from ams.bench.harness import Measurement, summarize
 logger = logging.getLogger(__name__)
 
 INIT_PHASES: tuple[str, ...] = (
-    "mats", "parse", "evaluate", "finalize", "postinit",
+    "mats", "parse", "evaluate", "finalize", "init",
 )
 
 TIER_A_ROUTINES: tuple[str, ...] = ("DCOPF", "RTED", "ED", "ACOPF")
@@ -93,7 +93,7 @@ def bench_routine_init_phases(
 
             t0 = time.perf_counter()
             rtn.init()
-            phase_times["postinit"] = time.perf_counter() - t0
+            phase_times["init"] = time.perf_counter() - t0
 
             if i >= warmup_reps:
                 for phase in INIT_PHASES:
@@ -132,9 +132,11 @@ def bench_routine_solve(
 ) -> Measurement:
     """Time ``rtn.run(solver=...)`` wall-clock.
 
-    Loads + inits once outside the measured window; each rep calls
-    ``rtn.run(solver=...)``. Setup cost is excluded from the timing
-    so the measurement reflects solver + model evaluation, not I/O.
+    Loads + explicitly initializes the routine once outside the
+    measured window; each rep then calls ``rtn.run(solver=...)`` so
+    the measurement reflects solver + model evaluation, not load or
+    init. ``rtn.init()`` is called explicitly so the first timed rep
+    is insensitive to ``warmup_reps``.
     """
     try:
         sp = ams.load(
@@ -142,9 +144,10 @@ def bench_routine_solve(
             setup=True, no_output=True, default_config=True,
         )
         rtn = sp.routines[routine]
+        rtn.init()
     except Exception as exc:
         logger.warning(
-            "bench solve %s/%s/%s: load failed: %s",
+            "bench solve %s/%s/%s: load/init failed: %s",
             routine, case.name, solver, exc,
         )
         return summarize(
@@ -217,13 +220,12 @@ def run_tier_a(
 ) -> list[Measurement]:
     """Run the full Tier A suite and return all Measurements.
 
-    Emits ~40 measurements in three groups:
+    Emits 53 measurements across three groups:
 
-    - ``case_load`` for every entry in ``CASE_LADDER``.
-    - ``routine_init_phase`` = 5 phases × 4 routines × 2 routine
-      cases = 40 (but collected as per-phase Measurements, so each
-      Measurement is one row).
-    - ``routine_solve`` = 4 routines × 2 routine cases = 8.
+    - ``case_load``: 5 (one per entry in ``CASE_LADDER``).
+    - ``routine_init_phase``: 40 (5 phases × 4 routines × 2 routine
+      cases; one Measurement per phase).
+    - ``routine_solve``: 8 (4 routines × 2 routine cases).
     """
     results: list[Measurement] = []
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,30 +1,93 @@
-"""Smoke test for the AMS benchmark suite scaffold.
+"""Smoke tests for the AMS benchmark suite.
 
-Keeps ``ams/bench/`` honest: if a refactor breaks the CLI entry point
-or the output schema, this test fails loudly. Full perf runs are not
-exercised here — that's the suite's own job.
+Kept fast so they can run as part of the regular test suite. Real
+perf measurement isn't exercised here — that's what
+``python -m ams.bench --suite tier_a`` is for.
 """
 import json
 import subprocess
 import sys
 
 
-def test_bench_cli_emits_valid_schema_v1_report():
-    """``python -m ams.bench`` emits a schema-v1 JSON with env captured."""
+def test_bench_public_exports_are_callable():
+    """All public names from ams.bench import and are callable."""
+    from ams.bench import (
+        SCHEMA_VERSION, Measurement, build_report, capture_env,
+        measure, run_smoke, run_tier_a, summarize,
+    )
+    assert SCHEMA_VERSION == 1
+    assert Measurement.__name__ == "Measurement"
+    for fn in (measure, summarize, capture_env, build_report, run_smoke, run_tier_a):
+        assert callable(fn)
+
+
+def test_bench_env_capture_has_expected_fields():
+    """capture_env() always returns a dict with the documented fields."""
+    from ams.bench import capture_env
+    env = capture_env()
+    assert isinstance(env, dict)
+    for key in (
+        "timestamp", "python", "platform", "machine", "cpu_brand",
+        "cpu_count", "memory_total_gb", "memory_available_gb",
+        "memory_percent_used_at_start", "blas_backend", "conda_env",
+        "git_commit", "git_dirty", "running_under_pytest", "tool_versions",
+    ):
+        assert key in env, f"missing env field: {key}"
+    assert env["python"].startswith("3.")
+    assert env["running_under_pytest"] is True
+    assert "ltbams" in env["tool_versions"]
+
+
+def test_bench_build_report_shape():
+    """build_report() wraps env + results in the versioned envelope."""
+    from ams.bench import build_report, capture_env
+    report = build_report(suite="tier_a", environment=capture_env(), results=[])
+    assert report["schema_version"] == 1
+    assert report["suite"] == "tier_a"
+    assert report["environment"]["running_under_pytest"] is True
+    assert report["results"] == []
+
+
+def test_bench_measure_catches_exception_and_reports_error():
+    """A fn that always raises lands as a Measurement with error set."""
+    from ams.bench import measure
+
+    def boom():
+        raise RuntimeError("intentional test failure")
+
+    m = measure(boom, name="boom", group="test", reps=3, warmup_reps=0)
+    assert m.error is not None
+    assert "intentional test failure" in m.error
+    assert m.raw_s == []
+    assert m.mean_s is None
+
+
+def test_bench_cli_smoke_suite_emits_valid_schema_v1_report():
+    """``python -m ams.bench --suite smoke`` runs end-to-end and emits valid JSON."""
     result = subprocess.run(
-        [sys.executable, "-m", "ams.bench", "--suite", "tier_a"],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=30,
+        [sys.executable, "-m", "ams.bench", "--suite", "smoke",
+         "--reps", "1", "--warmup-reps", "0"],
+        capture_output=True, text=True, check=True, timeout=60,
     )
     report = json.loads(result.stdout)
 
     assert report["schema_version"] == 1
-    assert report["suite"] == "tier_a"
+    assert report["suite"] == "smoke"
     assert isinstance(report["results"], list)
+    assert len(report["results"]) >= 1
 
-    env = report["environment"]
-    assert env["python"].startswith("3.")
-    assert "ltbams" in env["tool_versions"]
-    assert "andes" in env["tool_versions"]
+    # Each result carries the schema v1 required fields.
+    for res in report["results"]:
+        for key in ("name", "group", "reps", "warmup_reps", "raw_s",
+                    "routine", "case", "solver", "phase", "metadata"):
+            assert key in res, f"result missing required field {key}: {res}"
+
+
+def test_bench_cli_rejects_unknown_suite():
+    """argparse's choices= should catch typos before we hit any ams.load."""
+    result = subprocess.run(
+        [sys.executable, "-m", "ams.bench", "--suite", "not_a_real_suite"],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr or "not_a_real_suite" in result.stderr


### PR DESCRIPTION
## Summary

Builds on the M1 scaffold (PR #219). `python -m ams.bench --suite tier_a` now emits **53 real measurements** across 5 cases and 4 routines. Also adds a fast `--suite smoke` for CI and richer environment capture.

**Design doc:** `.claude/projects/andes_decoupling/step_2_4.md`

### Benchmark inventory (Tier A)

| group | count | description |
|---|---|---|
| `case_load` | 5 | `ams.load` across case5 / ieee14_uced / ieee39_uced / case300 / npcc_uced |
| `routine_init_phase` | 40 | 4 routines × 2 routine cases × 5 phases (mats/parse/evaluate/finalize/postinit) |
| `routine_solve` | 8 | 4 routines × 2 routine cases; default `--solver CLARABEL` |

**4 routines:** DCOPF, RTED, ED, ACOPF. UC / UC2 are MIPs and deferred to Tier B (CLARABEL doesn't do MIP).

### Schema v1 `Measurement` — extended

Added structured dimensions so a future dashboard / cloud reporter can filter without string-parsing `name`:
- `routine` (e.g. `"DCOPF"`)
- `case` (e.g. `"ieee14_uced"`)
- `solver` (e.g. `"CLARABEL"`)
- `phase` (e.g. `"mats"`, only set for `routine_init_phase`)
- `metadata` (dict, escape hatch for future tags)

### Environment capture — expanded

| field | source |
|---|---|
| `memory_total_gb`, `memory_available_gb`, `memory_percent_used_at_start` | `psutil` (already an AMS runtime dep) |
| `cpu_brand` | Linux `/proc/cpuinfo`, macOS `sysctl`, Windows fallback |
| `git_commit`, `git_dirty` | `git rev-parse` + `git status --porcelain` via `subprocess` |
| `blas_backend` | `numpy.show_config(mode="dicts")` |
| `conda_env` | `CONDA_DEFAULT_ENV` env var |
| `running_under_pytest` | `"pytest" in sys.modules` |

Every field degrades gracefully to `None` / `"unknown"` if undetectable — env capture must never raise.

### CLI additions

- `--solver CLARABEL` (default). Captured per-result so runs with different solvers stay comparable.
- `--suite` now validated by `argparse` choices: `{smoke, tier_a}`.
- Stdout redirected to stderr during suite execution so chatty libraries (PYPOWER prints during ACOPF) don't corrupt the JSON report.

### Interpretation note — init-phase is warm-path

`ams.load(setup=True)` already runs the first-time CVXPY compile; subsequent `mats.build(force=True)` / `om.parse(force=True)` exercise **re-execution**, not cold-start. Sample numbers on Apple M3 Pro: mats ~0.6ms, parse ~3.5ms, evaluate ~5ms, finalize + postinit near-zero. Cold-start timing is future Tier B work. Still a useful regression signal for the interactive-iteration path.

## Sample output (abridged)

```json
{
  "schema_version": 1,
  "suite": "tier_a",
  "environment": {
    "cpu_brand": "Apple M3 Pro",
    "memory_total_gb": 38.65,
    "blas_backend": "accelerate",
    "git_commit": "...",
    "git_dirty": false,
    "tool_versions": { "ltbams": "...", "andes": "2.0.0", "cvxpy": "1.7.5", ... }
  },
  "results": [
    {
      "name": "DCOPF/ieee14_uced/CLARABEL",
      "group": "routine_solve",
      "routine": "DCOPF", "case": "ieee14_uced", "solver": "CLARABEL",
      "mean_s": 0.0007, "stdev_s": 0.00001, "raw_s": [0.0007, ...]
    }
  ]
}
```

## Test plan

- [x] `python -m ams.bench --suite smoke --reps 1 --warmup-reps 0` — ~3s, 2 measurements, valid JSON.
- [x] `python -m ams.bench --suite tier_a` — 53 measurements, 0 errors across all groups, consistent per-rep timings (stdev ≈ 0 on quiet laptop).
- [x] `pytest tests/test_bench.py -v` — 6 passed in 3.72s.
- [x] `flake8 ams/bench/ tests/test_bench.py --max-line-length=120` — clean.
- [x] Full suite: **315 passed**, 9 warnings, 52.35s (was 310 / 50.46s at M1; +5 new bench tests, +1.89s wall-clock).

## Follow-ups (not in this PR)

- **M3**: capture first real baseline to `bench/baselines/2026-04-22_develop.json`, expand the `bench/README.md` stub with run / interpret / submit docs.
- **M4** (optional): Tier B — cold-start timing variant, co-sim end-to-end, solver sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)