### PR TITLE
Silence Codacy false positives and fix B110 in bench env capture

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,4 +1,14 @@
 ---
+# Top-level Codacy repo config. Pattern-level rule disabling is NOT
+# expressible here (per Codacy docs) — it lives either:
+#   (a) in the Codacy web UI at "Project -> Code Patterns", or
+#   (b) in tool-native config files checked into the repo, which
+#       Codacy's engines honor when running those tools:
+#         - pyproject.toml [tool.bandit] -> skips = [...]
+#         - pyproject.toml [tool.pydocstyle] -> add-ignore = "..."
+#         - .prospector.yaml -> pydocstyle: { disable: [...] }
+# See those files for current disables and rationale.
+
 engines:
   flake8:
     enabled: true

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,12 @@
+---
+# Prospector configuration. Codacy runs prospector as its Python linter
+# umbrella; tool-level disables here propagate to Codacy's static analysis
+# findings on every PR.
+
+pydocstyle:
+  # AMS follows PEP 257 defaults: summary on first line (D212), no blank
+  # line before class docstrings (D211). Disable the conflicting minority
+  # choices so they don't fire as false positives.
+  disable:
+    - D203  # "1 blank line required before class docstring" — conflicts with D211
+    - D213  # "Multi-line docstring summary should start at second line" — conflicts with D212

--- a/ams/bench/env.py
+++ b/ams/bench/env.py
@@ -96,8 +96,8 @@ def _cpu_brand() -> str:
             for line in proc_cpuinfo.read_text().splitlines():
                 if line.startswith("model name"):
                     return line.split(":", 1)[1].strip()
-        except Exception:  # env capture must never raise
-            pass
+        except Exception as exc:  # env capture must never raise
+            logger.debug("bench env: /proc/cpuinfo read failed: %s", exc)
     # macOS: sysctl
     try:
         out = subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,21 @@ exclude = ["tests", "tests.*"]
 
 [tool.setuptools]
 license-files = []
+
+[tool.bandit]
+# Skip rules that fire false positives on AMS's use of subprocess.
+# `ams/bench/env.py` runs subprocess only for legitimate environment
+# capture (`sysctl` for CPU brand, `git rev-parse`/`git status` for SHA
+# + dirty flag) with literal list args — no shell, no user-controlled
+# input. B110 (try/except/pass) is NOT skipped so real swallowed errors
+# stay visible. Codacy honors this section when running Bandit.
+skips = ["B404", "B603"]
+
+[tool.pydocstyle]
+# AMS docstrings follow PEP 257 defaults: summary on the first line
+# (D212) and no blank line before class docstrings (D211). Skip the
+# conflicting minority choices (D203, D213) so dozens of style-
+# preference findings don't surface on every PR. See also
+# `.prospector.yaml` which configures the same via Codacy's prospector
+# engine.
+add-ignore = "D203,D213"


### PR DESCRIPTION
## Summary

Pre-2.3 housekeeping. Uses the Codacy account API to read the **exact** findings on the two PRs that tripped the "not up to standards" badge (#219 and #221) — 21 issues total — and addresses them cleanly:

| finding | count | verdict |
|---|---|---|
| Prospector pydocstyle **D213** (summary on 2nd line) | 11 | False positive — we follow PEP 257 / D212 |
| Prospector pydocstyle **D203** (blank line before class docstring) | 1 | False positive — we follow PEP 257 / D211 |
| Bandit **B603** (subprocess with list args) | 3 | False positive — literal commands, no shell, no user input |
| Bandit **B404** (import subprocess) | 1 | False positive — import is necessary and safely used |
| Bandit **B110** (try / except / pass) | 1 | **Real quality issue** — silently swallowed `/proc/cpuinfo` errors |

## Changes

1. **`pyproject.toml`** — add `[tool.bandit]` with `skips = ["B404", "B603"]` and `[tool.pydocstyle]` with `add-ignore = "D203,D213"`. Silences style / safe-subprocess false positives for local runs of these tools AND for Codacy (which honors tool-native config).
2. **`.prospector.yaml` (new)** — disable pydocstyle D203 / D213. Codacy's Prospector engine reads this when running its analysis.
3. **`.codacy.yml`** — add header comment pointing future readers at `pyproject.toml` / `.prospector.yaml` as the config source of truth for per-pattern disables (since `.codacy.yml` itself cannot disable individual patterns, per Codacy docs).
4. **`ams/bench/env.py:99`** — fix B110 for real:
   ```diff
   -        except Exception:  # env capture must never raise
   -            pass
   +        except Exception as exc:  # env capture must never raise
   +            logger.debug("bench env: /proc/cpuinfo read failed: %s", exc)
   ```

Important: **B110 stays on Bandit's scanning list** (not in the skips) so any future accidental silent-swallow pattern still gets caught.

## Why `pyproject.toml` + `.prospector.yaml` instead of `.codacy.yml`

Per <https://docs.codacy.com/repositories-configure/codacy-configuration-file/>, `.codacy.yml` supports `engines`, `languages`, `exclude_paths`, `include_paths` — but explicitly does **not** support disabling individual pattern IDs. Pattern-level disabling lives either in the web UI's "Code Patterns" page or in tool-native config files. Tool-native keeps the config versioned with the code and silences the same rules for developers running the tools locally.

## Test plan

- [x] `pytest tests/test_bench.py tests/test_warnings.py -v` — 9 passed in 5.73 s.
- [x] `flake8 ams/bench/env.py --max-line-length=120` — clean.
- [x] `python -m ams.bench --suite smoke` — 2 results / 0 errors, schema v1 valid.
- [x] Manual verification: `/proc/cpuinfo` branch's behavior unchanged (no Linux `/proc/cpuinfo` on macOS, so the except branch doesn't execute during testing; code review confirms `logger.debug` keeps the function exception-safe).

## Scope note

This is a pre-2.3 cleanup. Separate from the Phase-2 decoupling work itself; kept tight so the tag-release step stays mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)