### PR TITLE
Move flake8 config to pyproject.toml [tool.flake8]

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-exclude = .git,__pycache__,build,dist,demos,cases,dev,ams/solver/pypower/,cards,versioneer.py,ams/_version.py,docs/source/conf.py,docs/source/_build,benchmarks,andes/pycode,scripts,.history,ams/pypower,icebar/*
-max-line-length=115

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "coverage", "flake8", "numpydoc", "toml"]
+dev = ["pytest", "pytest-cov", "coverage", "flake8", "Flake8-pyproject", "numpydoc", "toml"]
 nlp = ["PYPOWER", "pyoptinterface", "gurobipy", "gurobi-optimods"]
 doc = [
     "pandoc",
@@ -89,3 +89,27 @@ skips = ["B404", "B603"]
 # `.prospector.yaml` which configures the same via Codacy's prospector
 # engine.
 add-ignore = "D203,D213"
+
+[tool.flake8]
+max-line-length = 115
+exclude = [
+    ".git",
+    "__pycache__",
+    "build",
+    "dist",
+    "demos",
+    "cases",
+    "dev",
+    "ams/solver/pypower/",
+    "cards",
+    "versioneer.py",
+    "ams/_version.py",
+    "docs/source/conf.py",
+    "docs/source/_build",
+    "benchmarks",
+    "andes/pycode",
+    "scripts",
+    ".history",
+    "ams/pypower",
+    "icebar/*",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "coverage", "flake8", "Flake8-pyproject", "numpydoc", "toml"]
+dev = ["pytest", "pytest-cov", "coverage", "flake8", "flake8-pyproject", "numpydoc", "toml"]
 nlp = ["PYPOWER", "pyoptinterface", "gurobipy", "gurobi-optimods"]
 doc = [
     "pandoc",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ pytest
 pytest-cov
 coverage
 flake8
-Flake8-pyproject
+flake8-pyproject
 numpydoc
 toml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,6 @@ pytest
 pytest-cov
 coverage
 flake8
+Flake8-pyproject
 numpydoc
 toml


### PR DESCRIPTION
## Summary

First step in the `pyproject.toml` consolidation effort. Retires `.flake8` in favor of a `[tool.flake8]` section in `pyproject.toml`, with the `Flake8-pyproject` plugin pulling the config at lint time. Line-length and exclude list are preserved verbatim (115 + the same directory list).

- `.flake8` deleted
- `pyproject.toml` gains `[tool.flake8]` (line length 115, same excludes) and `Flake8-pyproject` in `[project.optional-dependencies].dev`
- `requirements-dev.txt` gains `Flake8-pyproject` (CI installs from this file via mamba — conda-forge ships it as `flake8-pyproject` noarch v1.2.4, MIT)

This is Phase A.1 of a larger consolidation. Phase A.2 (`setup.cfg`) and Phase B (`versioneer` → `setuptools-scm`) will land separately — A.2 turned out to be unimplementable without retiring the vendored versioneer first. Phase A.3 (retire `requirements*.txt`) is larger than initially scoped and will be a dedicated PR.

## Test plan

- [x] Plugin active: `flake8 --version` on andesre shows `Flake8-pyproject: 1.2.4` among plugins
- [x] Zero-finding parity: `flake8 .` emits 0 findings on this branch and on master (no lint regression)
- [x] Line-length enforcement: a deliberate 206-char line in `ams/` is flagged `E501 (> 115)`; same line inside `icebar/` is correctly skipped per the exclude
- [ ] CI lint jobs pass on this PR (`codecov.yml`, `compatibility.yml`, `publish-pypi.yml` all invoke `flake8 .`)
- [ ] **Watch item:** first post-merge Codacy run. If Codacy's flake8 engine container doesn't ship `Flake8-pyproject`, it will revert to flake8 defaults (line length 79, no excludes) and surface phantom findings. Rollback is a single revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)