### PR TITLE
Release notes for v1.2.0 and zsh-safe install commands

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,7 +66,7 @@ set up your fork for local development::
 
     $ mkvirtualenv ams
     $ cd ams/
-    $ pip install -e .[dev]
+    $ pip install -e '.[dev]'
 
 4. Create a branch for local development::
 

--- a/README.md
+++ b/README.md
@@ -113,16 +113,19 @@ pip install ltbams
 You can also install with optional dependencies, such as ``dev``, ``docs``, and ``nlp``:
 
 ```bash
-pip install ltbams[dev]
-pip install ltbams[docs]
-pip install ltbams[nlp]
+pip install 'ltbams[dev]'
+pip install 'ltbams[docs]'
+pip install 'ltbams[nlp]'
 ```
 
 Or install with all optional dependencies:
 
 ```bash
-pip install ltbams[all]
+pip install 'ltbams[all]'
 ```
+
+> **Note:** Single quotes are required in `zsh` (the default shell on macOS)
+> because `[...]` is a glob pattern. They are harmless on other shells.
 
 Install from conda-forge using conda:
 

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -83,7 +83,13 @@ To install packages in the ``dev`` when installing AMS, do:
 
 .. code:: bash
 
-    pip install .[dev]
+    pip install '.[dev]'
+
+.. note::
+
+    Single quotes are required in ``zsh`` (the default shell on macOS)
+    because ``[...]`` is a glob pattern. The quotes are harmless on
+    other shells.
 
 .. _Develop Install:
 
@@ -125,7 +131,7 @@ Install AMS together with the extras you need from ``pyproject.toml``:
 
 .. code:: bash
 
-    pip install -e .[dev,doc,nlp]
+    pip install -e '.[dev,doc,nlp]'
 
 If you prefer conda/mamba for the heavy binary dependencies, install
 those first, then ``pip install`` AMS:
@@ -133,7 +139,7 @@ those first, then ``pip install`` AMS:
 .. code:: bash
 
     mamba install -y kvxopt numpy scipy sympy pandas matplotlib cvxpy
-    pip install -e .[dev,doc,nlp]
+    pip install -e '.[dev,doc,nlp]'
 
 Note the dot at the end. Pip will take care of the rest.
 
@@ -158,9 +164,10 @@ Note the dot at the end. Pip will take care of the rest.
 .. note::
 
     To install extra support packages, one can append ``[NAME_OF_EXTRA]`` to
-    ``pip install -e .``. For example, ``pip install -e .[doc]`` will
+    ``pip install -e .``. For example, ``pip install -e '.[doc]'`` will
     install packages to support documentation when installing AMS in the
-    development, editable mode.
+    development, editable mode. The single quotes protect the square
+    brackets from being interpreted as a shell glob pattern.
 
 Updating AMS
 ==============

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -6,6 +6,45 @@ Release notes
 
 The APIs before v3.0.0 are in beta and may change without prior notice.
 
+v1.2
+==========
+
+v1.2.0 (2026-04-23)
+----------------------
+
+**Breaking changes:**
+
+- Requires ANDES >= 2.0.0
+- Minimum Python version raised to 3.11 (supported: 3.11, 3.12, 3.13)
+- Installation now uses pyproject extras instead of ``requirements*.txt``
+  files. Development install: ``pip install -e '.[dev,nlp]'``; docs:
+  ``pip install -e '.[doc]'`` (single quotes are required in ``zsh``
+  because ``[...]`` is a glob pattern)
+- In routine ``e_str`` expressions, multiplication must be explicit:
+  use ``@`` for matrix-vector, ``mul()`` for element-wise, or ``*`` for
+  scalar. The previous automatic ``word*word → @`` rewrite has been
+  removed. See :doc:`/modeling/routine` for details
+
+**New:**
+
+- Performance benchmark suite under ``ams.bench``. Run
+  ``python -m ams.bench`` to reproduce timings across standard cases
+  and routines; baselines in ``bench/baselines/``
+
+**Improvements:**
+
+- ``import ams`` is faster and no longer instantiates an ANDES
+  ``System`` at import time
+- CLI: ``ams`` without a subcommand now prints help cleanly; unknown
+  commands produce a clear error instead of a traceback
+- Loading a case produces far fewer warnings (retired config keys are
+  now silently purged instead of flagged on every startup)
+
+**Internal:**
+
+- Build system migrated from ``versioneer`` to ``setuptools-scm``;
+  this is the first release produced by the new pipeline
+
 v1.0
 ==========
 


### PR DESCRIPTION
## Summary

- Add a user-facing **v1.2.0** section to ``docs/source/release-notes.rst`` covering the breaking changes (ANDES 2.0 required, Python 3.11+, pyproject extras install, ``e_str`` multiplication semantics), the new ``ams.bench`` benchmark suite, and user-visible improvements (faster ``import ams``, cleaner CLI, fewer config warnings).
- Quote ``[extras]`` install specs throughout user-facing docs so the commands don't fail under ``zsh`` (the default shell on macOS), where ``[...]`` is interpreted as a glob pattern. Touched: ``README.md``, ``docs/source/getting_started/install.rst``, ``CONTRIBUTING.rst``.

Docs-only PR; no code changes. Needs to land before the ``v1.2.0`` tag is cut so the tagged commit carries the release notes.

## Test plan

- [ ] Render check via ReadTheDocs preview (RTD will build this branch on PR open)
- [ ] Confirm ``pip install -e '.[dev,nlp]'`` works in a fresh zsh session on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)