### PR TITLE
perf: drop dense temporaries in build_lodf and O(ng²) in build_cg

### DIFF
--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 import numpy as np
 
-from ams.utils.func import safe_div
 from ams.utils.misc import elapsed
 
 from ams.opt import Param
@@ -367,8 +366,8 @@ class MatProcessor:
         on_gen_idx = [idx_gen[i] for i in on_gen]  # idx of online generators
         on_gen_bus = system.StaticGen.get(src='bus', attr='v', idx=on_gen_idx)
 
-        row = np.array([system.Bus.idx2uid(x) for x in on_gen_bus])
-        col = np.array([idx_gen.index(x) for x in on_gen_idx])
+        row = np.asarray(system.Bus.idx2uid(on_gen_bus))
+        col = np.asarray(system.StaticGen.idx2uid(on_gen_idx))
         self.Cg._v = sps.csr_matrix((np.ones(len(on_gen_idx)), (row, col)), (nb, ng))
         self.Cg.col_names = idx_gen
         self.Cg.row_names = system.Bus.idx.v
@@ -751,9 +750,13 @@ class MatProcessor:
         for luidi in luidp:
             H_chunk = ptdf @ self.Cft._v[:, luidi]
             h_chunk = H_chunk.diagonal(-luidi[0])
-            rden = safe_div(np.ones(H_chunk.shape),
-                            np.tile(np.ones_like(h_chunk) - h_chunk, (nbranch, 1)))
-            H_chunk = H_chunk.multiply(rden).tolil()
+            # column-scale: H_chunk[i, j] /= (1 - h_chunk[j]); preserves
+            # safe_div semantics by zeroing columns where (1 - h_chunk) == 0
+            denom = 1.0 - h_chunk
+            inv = np.zeros_like(denom)
+            mask = denom != 0
+            inv[mask] = 1.0 / denom[mask]
+            H_chunk = (H_chunk @ sps.diags(inv)).tolil()
             # NOTE: use lil_matrix to set diagonal values as -1
             rsid = sps.diags(H_chunk.diagonal(-luidi[0])) + sps.eye(H_chunk.shape[1])
             if H_chunk.shape[0] > rsid.shape[0]:

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -14,6 +14,14 @@ v1.2.1 (unreleased)
 
 **Improvements:**
 
+- ``MatProcessor.build_lodf``: replace the dense ``np.ones`` + ``np.tile``
+  column-broadcast inside the chunk loop with sparse column scaling via
+  ``sps.diags(1 / (1 - h_chunk))``. Removes a transient
+  ``nbranch × step`` dense allocation that reached ~1 GB on
+  ~70k-bus grids. Numerical output is unchanged.
+- ``MatProcessor.build_cg``: replace the O(ng²) ``list.index`` lookup
+  with ``StaticGen.idx2uid`` for O(ng) total cost. Matters as
+  generator counts grow; modest at current case sizes.
 - ``MatProcessor.build_ptdf``: factorize the reduced bus susceptance
   matrix once via :func:`scipy.sparse.linalg.splu` and reuse the
   factorization across all line chunks. Removes the dense full-``Bbus``

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -15,10 +15,11 @@ v1.2.1 (unreleased)
 **Improvements:**
 
 - ``MatProcessor.build_lodf``: replace the dense ``np.ones`` + ``np.tile``
-  column-broadcast inside the chunk loop with sparse column scaling via
-  ``sps.diags(1 / (1 - h_chunk))``. Removes a transient
-  ``nbranch × step`` dense allocation that reached ~1 GB on
-  ~70k-bus grids. Numerical output is unchanged.
+  column-broadcast inside the chunk loop with sparse column scaling
+  that divides each column by ``(1 - h_chunk[j])``, zeroing columns
+  where the denominator is zero to preserve the prior ``safe_div``
+  behavior. Removes a transient ``nbranch × step`` dense allocation
+  that reached ~1 GB on ~70k-bus grids. Numerical output is unchanged.
 - ``MatProcessor.build_cg``: replace the O(ng²) ``list.index`` lookup
   with ``StaticGen.idx2uid`` for O(ng) total cost. Matters as
   generator counts grow; modest at current case sizes.


### PR DESCRIPTION
## Summary

Two MatProcessor cleanups identified during the architectural review that followed PR #231 but were intentionally scoped out of that PR.

- ``build_lodf``: the per-chunk column-scaling step allocates a dense ``(nbranch × step)`` ones-matrix and a same-shape ``np.tile`` broadcast just to divide each column by ``(1 - h_chunk[j])``. Replace with sparse column scaling via ``sps.diags``. Same math; numerical output is identical (``max|new - old| = 0.0`` on case14/118/300/case_ACTIVSg2000). The transient peak allocation drops from ``nbranch * step * 8`` bytes per chunk to bounded by ``H_chunk``'s own footprint plus a length-``step`` ``inv`` vector. At ~70k buses with ``step=1000`` this saves ~1 GB transient per chunk.
- ``build_cg``: the generator connectivity builder fetched column indices via ``[idx_gen.index(x) for x in on_gen_idx]``, which is O(ng) per call → O(ng²) total. Replace with ``StaticGen.idx2uid`` (hash lookup). Modest absolute speedup at current case sizes (case_ACTIVSg2000 ng=544: 5.53 → 5.11 ms, ~7%); the win grows quadratically with generator count.

## Numerical equivalence

LODF chunk-by-chunk diff against the prior implementation: ``max|new − old| = 0.0`` on case14, case118, case300, case_ACTIVSg2000.

## Wall-clock (warm cache, this machine)

| Case | LODF (incremental, step=500) | build_cg |
|---|---|---|
| | OLD → NEW | OLD → NEW |
| case118 (nb=118, ng=54) | 6.8 → 6.7 ms | 0.13 → 0.13 ms |
| case300 (nb=300, ng=69) | 25.5 → 27.6 ms | 0.19 → 0.18 ms |
| case_ACTIVSg2000 (nb=2000, ng=544) | 2216 → 2310 ms | 5.53 → 5.11 ms |

LODF wall-clock is in the noise band at these sizes — the win is **memory**, not wall-clock at 2k bus. Real speedup will surface on grids beyond ~10k buses where the old transient allocation enters GB territory and starts pressuring page cache. ``build_cg`` is asymptotic-only at current sizes; useful as generator counts grow.

## What changed

- ``ams/core/matprocessor.py``:
  - ``build_lodf``: ``rden = safe_div(np.ones(...), np.tile(...))`` → masked ``inv`` vector + ``H_chunk @ sps.diags(inv)``.
  - ``build_cg``: ``[idx_gen.index(x) for x in on_gen_idx]`` → ``StaticGen.idx2uid(on_gen_idx)``; ``[Bus.idx2uid(x) for x in on_gen_bus]`` → ``Bus.idx2uid(on_gen_bus)``.
  - Drop unused ``safe_div`` import.
- ``docs/source/release-notes.rst``: bullets under ``v1.2.1 (unreleased)``.

## Out of scope (deferred)

The third item from the same review — ``MParam.v`` auto-densifying sparse matrices on every property access — is a **behavioral change to a property contract** and needs caller audit before landing. Tracked separately; will be its own PR.

## Test plan

- [x] ``pytest tests/`` — 318/318 pass
- [x] LODF chunk-by-chunk numerical equivalence vs prior implementation
- [x] Spot-check ``build_cg`` output on case_ACTIVSg2000 (matrix dims and nnz match)
- [ ] CI matrix on Linux/macOS/Windows + Python 3.11/3.12/3.13
- [ ] Codacy + ReadTheDocs

🤖 Generated with [Claude Code](https://claude.com/claude-code)