### PR TITLE
perf: stop MParam.v from auto-densifying sparse matrices

### DIFF
--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -616,8 +616,10 @@ class MatProcessor:
 
         Returns
         -------
-        PTDF : scipy.sparse.lil_matrix
-            Power transfer distribution factor.
+        PTDF : scipy.sparse.csr_matrix
+            Power transfer distribution factor. The result is built into a
+            ``lil_matrix`` for fast row-block assignment during the chunk
+            loop and frozen to ``csr_matrix`` before being returned.
 
         References
         ----------
@@ -706,7 +708,9 @@ class MatProcessor:
         It requires DC PTDF and Cft.
 
         For large cases where memory is a concern, use `incremental=True` to
-        calculate the sparse LODF in chunks in the format of scipy.sparse.lil_matrix.
+        calculate the sparse LODF in chunks. The result is assembled into a
+        ``lil_matrix`` for fast row-block assignment during the chunk loop
+        and frozen to ``csr_matrix`` before being returned.
 
         Parameters
         ----------
@@ -725,7 +729,7 @@ class MatProcessor:
 
         Returns
         -------
-        LODF : scipy.sparse.lil_matrix
+        LODF : scipy.sparse.csr_matrix
             Line outage distribution factor.
 
         References

--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -196,38 +196,50 @@ class MParam(Param):
                                           path=path,
                                           fmt='csv')
 
-        pd.DataFrame(data=self.v, columns=self.col_names, index=self.row_names).to_csv(path)
+        pd.DataFrame(data=self.dense(), columns=self.col_names, index=self.row_names).to_csv(path)
 
         return file_name
 
     @property
     def v(self):
         """
-        Return the value of the parameter.
+        Return the underlying value of the parameter.
+
+        For ``sparse=True`` MParams the underlying scipy.sparse matrix is
+        returned as-is. Use :meth:`dense` (or call ``.toarray()`` on the
+        sparse object directly) when an :class:`numpy.ndarray` is required.
         """
-        # NOTE: scipy.sparse matrix will return 2D array
-        # so we squeeze it here if only one row
-        if isinstance(self._v, (sps.csr_matrix, sps.lil_matrix, sps.csc_matrix)):
+        return self._v
+
+    def dense(self):
+        """
+        Return the parameter value as a dense :class:`numpy.ndarray`.
+
+        For sparse-stored MParams this materializes the full dense matrix
+        and squeezes a single-row result down to a 1D array (preserving
+        the historical 1-row shape contract). For dense storage this is
+        a no-op pass-through.
+        """
+        if sps.issparse(self._v):
             out = self._v.toarray()
             if out.shape[0] == 1:
                 return np.squeeze(out)
-            else:
-                return out
+            return out
         return self._v
 
     @property
     def shape(self):
         """
-        Return the shape of the parameter.
+        Return the shape of the parameter without materializing the value.
         """
-        return self.v.shape
+        return self._v.shape
 
     @property
     def n(self):
         """
-        Return the szie of the parameter.
+        Return the size of the parameter without materializing the value.
         """
-        return len(self.v)
+        return self._v.shape[0]
 
     @property
     def class_name(self):
@@ -658,6 +670,7 @@ class MatProcessor:
             lu = sps.linalg.splu(A, permc_spec=permc_spec)
 
         chunk = step if incremental else nline
+        # build with lil for fast row-block assignment, freeze to csr at the end
         H = sps.lil_matrix((nline, nbus))
 
         pbar = _init_pbar(total=100, unit='%', no_tqdm=no_tqdm)
@@ -668,6 +681,8 @@ class MatProcessor:
             sol = lu.solve(rhs).T
             H[start:end, noslack] = sol
             _update_pbar(pbar, end, nline)
+
+        H = H.tocsr()
 
         # reshape results into 1D array if only one line
         if isinstance(line, (int, str)):
@@ -768,6 +783,8 @@ class MatProcessor:
             LODF[:, [luid.index(i) for i in luidi]] = H_chunk
 
             _update_pbar(pbar, luid.index(luidi[-1]), nline)
+
+        LODF = LODF.tocsr()
 
         # reshape results into 1D array if only one line
         if isinstance(line, (int, str)):

--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -299,7 +299,9 @@ class NumOp(ROperationService):
     def v0(self):
         out = self.fun(self.u.v, **self.args)
         if self.array_out:
-            if not isinstance(out, np.ndarray):
+            # wrap genuine Python scalars in a 1-element ndarray; pass
+            # ndarrays and scipy.sparse matrices through untouched
+            if not isinstance(out, np.ndarray) and not spr.issparse(out):
                 out = np.array([out])
         return out
 

--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -300,9 +300,13 @@ class NumOp(ROperationService):
         out = self.fun(self.u.v, **self.args)
         if self.array_out:
             # wrap genuine Python scalars in a 1-element ndarray; pass
-            # ndarrays and scipy.sparse matrices through untouched
+            # ndarrays and scipy.sparse matrices through untouched;
+            # convert other array-likes (lists/tuples) via np.asarray
             if not isinstance(out, np.ndarray) and not spr.issparse(out):
-                out = np.array([out])
+                if np.isscalar(out):
+                    out = np.array([out])
+                else:
+                    out = np.asarray(out)
         return out
 
     @property

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -14,6 +14,25 @@ v1.2.1 (unreleased)
 
 **Improvements:**
 
+- ``MParam.v`` no longer auto-densifies sparse-stored matrices on every
+  property access. The underlying scipy.sparse object is now returned
+  as-is; a new ``MParam.dense()`` method materializes a dense
+  :class:`numpy.ndarray` when one is genuinely required. ``.shape`` and
+  ``.n`` consult the underlying value directly without densifying.
+  Together with the ``sparse=True`` declarations on the matrix
+  ``RParam`` consumers in ``DCPF`` / ``DCOPF`` / ``DCOPF2``, this lets
+  routines actually pass sparse matrices to CVXPY instead of silently
+  densifying them on every parameter set
+- ``MatProcessor.build_ptdf`` / ``build_lodf`` now finalize the result
+  as ``csr_matrix`` rather than leaving it as ``lil_matrix``. ``lil`` is
+  the right format for incremental row assignment during construction
+  but is poorly supported by downstream consumers (CVXPY, scipy ``COO``
+  conversion); freezing to ``csr`` at the end is the canonical pattern
+- ``NumOp.v0``: pass scipy.sparse outputs through untouched when
+  ``array_out=True``. Previously sparse results were wrapped in a
+  1-element :class:`numpy.ndarray` of object dtype, which broke the
+  subsequent ``csr_matrix`` conversion in :meth:`NumOp.v` for sparse
+  ``NumOp``\ s such as ``DCOPF2.PTDFt``
 - ``MatProcessor.build_lodf``: replace the dense ``np.ones`` + ``np.tile``
   column-broadcast inside the chunk loop with sparse column scaling
   that divides each column by ``(1 - h_chunk[j])``, zeroing columns

--- a/tests/test_matp.py
+++ b/tests/test_matp.py
@@ -134,34 +134,41 @@ class TestMatProcessorBasic(unittest.TestCase):
         one_vec = MParam(v=sps.csr_matrix(np.ones(self.ss.Bus.n)))
         # check if `_v` is `sps.csr_matrix` instance
         self.assertIsInstance(one_vec._v, sps.csr_matrix)
-        # check if `v` is 1D-array
-        self.assertEqual(one_vec.v.shape, (self.ss.Bus.n,))
+        # `.v` returns the underlying sparse object as-is; `.dense()`
+        # squeezes a 1-row sparse to a 1D ndarray
+        self.assertTrue(sps.issparse(one_vec.v))
+        self.assertEqual(one_vec.dense().shape, (self.ss.Bus.n,))
 
     def test_c(self):
         """
-        Test connectivity matrices.
+        Test connectivity matrices. `.v` returns the underlying sparse
+        object; `.dense()` materializes a dense ndarray.
         """
         # Test `Cg`
         self.assertIsInstance(self.mats.Cg._v, (sps.csr_matrix, sps.lil_matrix))
-        self.assertIsInstance(self.mats.Cg.v, np.ndarray)
+        self.assertTrue(sps.issparse(self.mats.Cg.v))
+        self.assertIsInstance(self.mats.Cg.dense(), np.ndarray)
         self.assertEqual(self.mats.Cg._v.max(), 1)
         np.testing.assert_equal(self.mats.Cg._v.sum(axis=0), np.ones((1, self.ng)))
 
         # Test `Cl`
         self.assertIsInstance(self.mats.Cl._v, (sps.csr_matrix, sps.lil_matrix))
-        self.assertIsInstance(self.mats.Cl.v, np.ndarray)
+        self.assertTrue(sps.issparse(self.mats.Cl.v))
+        self.assertIsInstance(self.mats.Cl.dense(), np.ndarray)
         self.assertEqual(self.mats.Cl._v.max(), 1)
         np.testing.assert_equal(self.mats.Cl._v.sum(axis=0), np.ones((1, self.nD)))
 
         # Test `Csh`
         self.assertIsInstance(self.mats.Csh._v, (sps.csr_matrix, sps.lil_matrix))
-        self.assertIsInstance(self.mats.Csh.v, np.ndarray)
+        self.assertTrue(sps.issparse(self.mats.Csh.v))
+        self.assertIsInstance(self.mats.Csh.dense(), np.ndarray)
         self.assertEqual(self.mats.Csh._v.max(), 1)
         np.testing.assert_equal(self.mats.Csh._v.sum(axis=0), np.ones((1, self.nsh)))
 
         # Test `Cft`
         self.assertIsInstance(self.mats.Cft._v, (sps.csr_matrix, sps.lil_matrix))
-        self.assertIsInstance(self.mats.Cft.v, np.ndarray)
+        self.assertTrue(sps.issparse(self.mats.Cft.v))
+        self.assertIsInstance(self.mats.Cft.dense(), np.ndarray)
         self.assertEqual(self.mats.Cft._v.max(), 1)
         np.testing.assert_equal(self.mats.Cft._v.sum(axis=0), np.zeros((1, self.nl)))
 
@@ -260,7 +267,7 @@ class TestBuildPTDF(unittest.TestCase):
                                           no_tqdm=True)
         np.testing.assert_array_almost_equal(ptdf_l2.todense(),
                                              self.ptdf_full[[2], :])
-        self.assertTrue(sps.isspmatrix_lil(ptdf_l2))
+        self.assertTrue(sps.issparse(ptdf_l2))
         self.assertIsNone(self.ss.mats.PTDF._v)
 
         # input list with single element
@@ -269,7 +276,7 @@ class TestBuildPTDF(unittest.TestCase):
                                            no_tqdm=False)
         np.testing.assert_array_almost_equal(ptdf_l2p.todense(),
                                              self.ptdf_full[[2], :])
-        self.assertTrue(sps.isspmatrix_lil(ptdf_l2p))
+        self.assertTrue(sps.issparse(ptdf_l2p))
         self.assertIsNone(self.ss.mats.PTDF._v)
 
         # input list with multiple elements
@@ -277,7 +284,7 @@ class TestBuildPTDF(unittest.TestCase):
                                            incremental=True, no_store=False)
         np.testing.assert_array_almost_equal(ptdf_l23.todense(),
                                              self.ptdf_full[2:4, :])
-        self.assertTrue(sps.isspmatrix_lil(ptdf_l23))
+        self.assertTrue(sps.issparse(ptdf_l23))
 
     def test_ptdf_incremental_step(self):
         """
@@ -286,7 +293,7 @@ class TestBuildPTDF(unittest.TestCase):
         # step < line length
         ptdf_c1 = self.ss.mats.build_ptdf(line=self.ss.Line.idx.v[2:4], incremental=True,
                                           no_store=False, step=1)
-        self.assertTrue(sps.isspmatrix_lil(ptdf_c1))
+        self.assertTrue(sps.issparse(ptdf_c1))
         self.assertIsNone(self.ss.mats.PTDF._v)
         np.testing.assert_array_almost_equal(ptdf_c1.todense(),
                                              self.ptdf_full[2:4, :],)
@@ -294,7 +301,7 @@ class TestBuildPTDF(unittest.TestCase):
         # step = line length
         ptdf_c2 = self.ss.mats.build_ptdf(line=self.ss.Line.idx.v[2:4], incremental=True,
                                           no_store=False, step=2)
-        self.assertTrue(sps.isspmatrix_lil(ptdf_c2))
+        self.assertTrue(sps.issparse(ptdf_c2))
         self.assertIsNone(self.ss.mats.PTDF._v)
         np.testing.assert_array_almost_equal(ptdf_c2.todense(),
                                              self.ptdf_full[2:4, :],)
@@ -302,7 +309,7 @@ class TestBuildPTDF(unittest.TestCase):
         # step > line length
         ptdf_c5 = self.ss.mats.build_ptdf(line=self.ss.Line.idx.v[2:4], incremental=True,
                                           no_store=False, step=5)
-        self.assertTrue(sps.isspmatrix_lil(ptdf_c5))
+        self.assertTrue(sps.issparse(ptdf_c5))
         self.assertIsNone(self.ss.mats.PTDF._v)
         np.testing.assert_array_almost_equal(ptdf_c5.todense(),
                                              self.ptdf_full[2:4, :],)
@@ -366,14 +373,14 @@ class TestBuildLODF(unittest.TestCase):
         np.testing.assert_array_almost_equal(lodf_l2.todense(),
                                              self.lodf_full[:, [2]],
                                              decimal=self.dec)
-        self.assertTrue(sps.isspmatrix_lil(lodf_l2))
+        self.assertTrue(sps.issparse(lodf_l2))
 
         # input list with single element
         lodf_l2p = self.ss.mats.build_lodf(line=[self.ss.Line.idx.v[2]], incremental=True, no_store=False)
         np.testing.assert_array_almost_equal(lodf_l2p.todense(),
                                              self.lodf_full[:, [2]],
                                              decimal=self.dec)
-        self.assertTrue(sps.isspmatrix_lil(lodf_l2p))
+        self.assertTrue(sps.issparse(lodf_l2p))
 
         # input list with multiple elements
         lodf_l23 = self.ss.mats.build_lodf(line=self.ss.Line.idx.v[2:4], incremental=True, no_store=False)
@@ -389,7 +396,7 @@ class TestBuildLODF(unittest.TestCase):
         lodf_c1 = self.ss.mats.build_lodf(line=self.ss.Line.idx.v[2:4],
                                           incremental=True,
                                           no_store=False, step=1)
-        self.assertTrue(sps.isspmatrix_lil(lodf_c1))
+        self.assertTrue(sps.issparse(lodf_c1))
         np.testing.assert_array_almost_equal(lodf_c1.todense(),
                                              self.lodf_full[:, 2:4],
                                              decimal=self.dec)
@@ -398,7 +405,7 @@ class TestBuildLODF(unittest.TestCase):
         lodf_c2 = self.ss.mats.build_lodf(line=self.ss.Line.idx.v[2:4],
                                           incremental=True,
                                           no_store=False, step=2)
-        self.assertTrue(sps.isspmatrix_lil(lodf_c2))
+        self.assertTrue(sps.issparse(lodf_c2))
         np.testing.assert_array_almost_equal(lodf_c2.todense(),
                                              self.lodf_full[:, 2:4],
                                              decimal=self.dec)
@@ -407,7 +414,7 @@ class TestBuildLODF(unittest.TestCase):
         lodf_c5 = self.ss.mats.build_lodf(line=self.ss.Line.idx.v[2:4],
                                           incremental=True,
                                           no_store=False, step=5)
-        self.assertTrue(sps.isspmatrix_lil(lodf_c5))
+        self.assertTrue(sps.issparse(lodf_c5))
         np.testing.assert_array_almost_equal(lodf_c5.todense(),
                                              self.lodf_full[:, 2:4],
                                              decimal=self.dec)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,7 +8,7 @@ from ams.core.service import NumOp, NumOpDual, ZonalSum
 
 
 def _as_dense(x):
-    """Return a dense ndarray view of either a sparse or dense input."""
+    """Return a dense ndarray from either a sparse or dense input."""
     return x.toarray() if sps.issparse(x) else np.asarray(x)
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,9 +1,15 @@
 import unittest
 import numpy as np
+import scipy.sparse as sps
 
 import ams
 from ams.core.matprocessor import MParam
 from ams.core.service import NumOp, NumOpDual, ZonalSum
+
+
+def _as_dense(x):
+    """Return a dense ndarray view of either a sparse or dense input."""
+    return x.toarray() if sps.issparse(x) else np.asarray(x)
 
 
 class TestService(unittest.TestCase):
@@ -25,14 +31,16 @@ class TestService(unittest.TestCase):
         Test `NumOp` without return function.
         """
         CftT = NumOp(u=self.ss.mats.Cft, fun=np.transpose)
-        np.testing.assert_array_equal(CftT.v.transpose(), self.ss.mats.Cft.v)
+        np.testing.assert_array_equal(_as_dense(CftT.v).transpose(),
+                                      self.ss.mats.Cft.dense())
 
     def test_NumOp_rfun(self):
         """
         Test `NumOp` with return function.
         """
         CftTT = NumOp(u=self.ss.mats.Cft, fun=np.transpose, rfun=np.transpose)
-        np.testing.assert_array_equal(CftTT.v, self.ss.mats.Cft.v)
+        np.testing.assert_array_equal(_as_dense(CftTT.v),
+                                      self.ss.mats.Cft.dense())
 
     def test_NumOp_ArrayOut(self):
         """


### PR DESCRIPTION
## Summary

Closes the third item from the post-PR #231 architectural review (the one explicitly deferred from #231 and #232 because it is a behavioral change to a property contract and needed a caller audit before landing).

``MParam.v`` previously called ``.toarray()`` on every property access for sparse-stored matrices. The contract now returns the underlying object as-is; a new ``MParam.dense()`` method materializes a dense :class:`numpy.ndarray` for the cases that actually need one. ``MParam.shape`` and ``.n`` consult ``_v`` directly so reading a matrix's shape no longer densifies it.

## Why this matters

The repo already declared the matrix consumers as sparse at the routine layer:

```python
# ams/routines/dcpf.py
self.Cg   = RParam(..., sparse=True, ...)
self.Cl   = RParam(..., sparse=True, ...)
self.CftT = RParam(..., sparse=True, ...)
self.Csh  = RParam(..., sparse=True, ...)
self.Bbus = RParam(..., sparse=True, ...)
self.Bf   = RParam(..., sparse=True, ...)
```

But ``RParam.v`` for these reads ``MParam.v``, which auto-densified before this PR. So **routines were passing dense matrices to CVXPY despite declaring them sparse**. On a 70k-bus PTDF that was ~40 GB allocated per parameter set; on incidental accesses (logging, ``repr``, ``.shape``, ``.n``, ``pd.DataFrame`` round-trips) every read paid the densification cost.

This PR makes the ``sparse=True`` plumbing actually work end-to-end.

## What changed

### Contract (``ams/core/matprocessor.py``)

- ``MParam.v`` returns ``self._v`` as-is. No more ``.toarray()``.
- New ``MParam.dense()`` returns a dense ``ndarray``, preserving the prior 1-row squeeze.
- ``MParam.shape`` → ``self._v.shape`` (no materialization).
- ``MParam.n`` → ``self._v.shape[0]`` (no materialization).

### Downstream changes needed to make sparse actually flow through to CVXPY

1. **``build_ptdf`` / ``build_lodf`` finalize as ``csr`` instead of ``lil``.** ``lil`` is the right format for incremental row-block assignment during construction but is poorly supported by CVXPY's canonicalization and by ``scipy``'s ``coo`` conversion path (the latter raises ``ValueError: truth value of an array with more than one element is ambiguous`` when fed a ``lil`` through certain code paths). Freezing to ``csr`` at the end is the canonical scipy pattern.

2. **``NumOp.v0``: pass ``scipy.sparse`` outputs through when ``array_out=True``.** Previously a non-``ndarray`` non-scalar result was wrapped in a 1-element ``np.array([sparse])`` of object dtype, which broke the subsequent ``csr_matrix`` conversion in ``NumOp.v``. Surfaces on ``DCOPF2.PTDFt = NumOp(u=PTDF, fun=np.transpose, sparse=True)`` — ``np.transpose`` on sparse now returns sparse, the wrap turns it into garbage, the wrapped result then breaks ``csr_matrix(...)``. Fix: only wrap genuine Python scalars.

3. **``MParam.export_csv``** switches from ``self.v`` to ``self.dense()`` for the ``pd.DataFrame`` constructor (pandas doesn't accept scipy sparse via its regular path).

### Test updates

- ``test_matp.py``: ``isinstance(.v, np.ndarray)`` → ``sps.issparse(.v)``; ``.dense()`` used where dense output is the actual contract being tested. ``isspmatrix_lil`` assertions on PTDF/LODF outputs relaxed to ``issparse`` (the lil format was an implementation detail).
- ``test_service.py``: NumOp transpose-equivalence asserts now compare via a small ``_as_dense`` helper that handles both sparse and dense.

## Numerical equivalence

DCOPF vs DCOPF2 on case14 (CLARABEL):

```
DCOPF  obj = 7642.591778, sum(pg) = 2.5900
DCOPF2 obj = 7642.591783, sum(pg) = 2.5900
obj diff: 5.13e-06
```

5.13e-6 is solver tolerance — identical to develop before this PR.

## Test plan

- [x] ``pytest tests/`` — 318/318 pass
- [x] DCOPF + DCOPF2 numerical equivalence on case14
- [x] DCOPF init + run on case_ACTIVSg2000 (no regressions)
- [ ] CI matrix on Linux/macOS/Windows × 3.11/3.12/3.13
- [ ] Codacy + ReadTheDocs

## Out of scope (for future)

- ``RParam.v``'s ``is_ext`` branch (``ams/core/param.py:176-177``) still calls ``.toarray()`` for externally-set sparse values. That code path is rarely used and changing it is an independent contract change; not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)