### PR TITLE
chore: ignore .claude/ directory recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ __pycache__/
 .idea/*
 
 # claude
-.claude/*
+.claude/
 
 # Sphinx documentation
 docs/source/modelref.rst


### PR DESCRIPTION
## Summary

The previous \`.gitignore\` pattern \`.claude/*\` only matched files **one level deep** (the \`*\` glob does not cross slashes per gitignore semantics), so anything under \`.claude/projects/<name>/...\` slipped through. As a result \`git status\` showed \`.claude/\` as untracked even though \`.claude/CLAUDE.md\` (one level deep) was correctly ignored.

Switch to \`.claude/\` (no glob), the canonical gitignore pattern for an ignored directory, which recursively covers the whole tree.

## Verification

\`\`\`
$ git status --ignored | grep -A1 'Untracked\\|Ignored'
# before: .claude/ shows under "Untracked"
# after:  .claude/ shows under "Ignored"
\`\`\`

## Test plan

- [x] \`git status\` no longer reports \`.claude/\` as untracked
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)