### PR TITLE
feat(cli): add 'ams --version' alias

### DIFF
--- a/ams/cli.py
+++ b/ams/cli.py
@@ -34,7 +34,14 @@ def create_parser():
         Parser with all AMS options
     """
 
+    from ams import __version__
+
     parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {__version__}')
 
     parser.add_argument(
         '-v', '--verbose',

--- a/ams/cli.py
+++ b/ams/cli.py
@@ -36,7 +36,7 @@ def create_parser():
 
     from ams import __version__
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog='ams')
 
     parser.add_argument(
         '--version',

--- a/ams/cli.py
+++ b/ams/cli.py
@@ -8,6 +8,7 @@ import os
 import platform
 import sys
 from time import strftime
+from ams import __version__
 from ams.main import config_logger
 from ams.utils.paths import get_log_dir
 from ams.routines import routine_cli
@@ -33,8 +34,6 @@ def create_parser():
     argparse.ArgumentParser
         Parser with all AMS options
     """
-
-    from ams import __version__
 
     parser = argparse.ArgumentParser(prog='ams')
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -14,6 +14,11 @@ v1.2.1 (unreleased)
 
 **Improvements:**
 
+- Add top-level ``ams --version`` flag that prints the AMS version
+  (``ams X.Y.Z``), following the standard CLI convention used by
+  ``pip``, ``pytest``, ``git``, and others. ``ams misc --version`` is
+  unchanged and still prints the multi-line dependency block (Python,
+  andes, numpy, cvxpy, solvers) for bug reports
 - ``MParam.v`` no longer auto-densifies sparse-stored matrices on every
   property access. The underlying scipy.sparse object is now returned
   as-is; a new ``MParam.dense()`` method materializes a dense

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,12 @@ class TestCLI(unittest.TestCase):
     def test_cli_parser(self):
         ams.cli.create_parser()
 
+    def test_cli_version_flag(self):
+        parser = ams.cli.create_parser()
+        with self.assertRaises(SystemExit) as cm:
+            parser.parse_args(['--version'])
+        self.assertEqual(cm.exception.code, 0)
+
     def test_cli_preamble(self):
         ams.cli.preamble()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
-import unittest
+import contextlib
+import io
 import os
+import unittest
 
+import ams
 import ams.main
 import ams.cli
 
@@ -12,9 +15,13 @@ class TestCLI(unittest.TestCase):
 
     def test_cli_version_flag(self):
         parser = ams.cli.create_parser()
-        with self.assertRaises(SystemExit) as cm:
-            parser.parse_args(['--version'])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with self.assertRaises(SystemExit) as cm:
+                parser.parse_args(['--version'])
         self.assertEqual(cm.exception.code, 0)
+        out = buf.getvalue().strip()
+        self.assertEqual(out, f'ams {ams.__version__}')
 
     def test_cli_preamble(self):
         ams.cli.preamble()


### PR DESCRIPTION
## Summary

Adds a top-level `ams --version` flag that prints the AMS version in the standard one-line form (`ams X.Y.Z`), matching the convention used by `pip`, `pytest`, `git`, `node`, and friends.

`ams misc --version` is **untouched** — it still prints the full multi-line dependency block (Python / andes / numpy / cvxpy / solvers) that's useful for bug reports.

Implementation uses argparse's stock `action='version'` (no custom Action class), so the parser handles printing and exit cleanly.

```
$ ams --version
ams 1.2.0.post13+ge0ff3e94f

$ ams misc --version
Python   3.12.0
ams      1.2.0.post13+ge0ff3e94f
andes    2.0.0
numpy    2.1.3
cvxpy    1.7.5
solvers  CLARABEL, GUROBI, MOSEK, OSQP,
         PIQP, SCIP, SCIPY, SCS
```

## Why

Surfaced during the `ltbams-feedstock` PR #39 work — `ams --version` is the natural choice for a "is the install working?" smoke test in conda-forge recipe `test:` blocks, but wasn't wired up. Users shouldn't have to discover the `misc` subcommand for the universal CLI convention.

Per discussion, the alias prints **only AMS's own version** (the standard practice). The richer dependency dump stays at `ams misc --version` where users who need it for bug reports can still find it.

## Test plan

- [x] `pytest tests/test_cli.py -v` — all 7 tests pass, including new `test_cli_version_flag`
- [x] Smoke: `ams --version` → `ams 1.2.0.post13+...`
- [x] Smoke: `ams misc --version` → unchanged multi-line block
- [x] Smoke: `ams --help` → lists `--version` near `--verbose`
- [x] Smoke: `ams run case5.m` parsing unaffected (no namespace collision)

## Follow-up (separate repo)

Once this lands and is in a release, swap `ams misc --version` → `ams --version` in `ltbams-feedstock/recipe/meta.yaml` test commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)