### PR TITLE
chore: finish MParam.v no-auto-densify contract

### DIFF
--- a/ams/core/param.py
+++ b/ams/core/param.py
@@ -8,7 +8,6 @@ import logging
 from typing import Optional, Iterable
 
 import numpy as np
-from scipy.sparse import issparse
 
 from ams.opt import Param
 
@@ -173,10 +172,7 @@ class RParam(Param):
             raise NotImplementedError(msg)
         if self.indexer is None:
             if self.is_ext:
-                if issparse(self._v):
-                    out = self._v.toarray()
-                else:
-                    out = self._v
+                out = self._v
             elif self.is_group:
                 out = self.owner.get(src=self.src, attr='v',
                                      idx=self.owner.get_all_idxes())

--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -450,8 +450,14 @@ class NumOpDual(NumOp):
     def v0(self):
         out = self.fun(self.u.v, self.u2.v, **self.args)
         if self.array_out:
-            if not isinstance(out, np.ndarray):
-                out = np.array([out])
+            # wrap genuine Python scalars in a 1-element ndarray; pass
+            # ndarrays and scipy.sparse matrices through untouched;
+            # convert other array-likes (lists/tuples) via np.asarray
+            if not isinstance(out, np.ndarray) and not spr.issparse(out):
+                if np.isscalar(out):
+                    out = np.array([out])
+                else:
+                    out = np.asarray(out)
         if self.sparse:
             return spr.csr_matrix(out)
         return out

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -19,6 +19,18 @@ v1.2.1 (unreleased)
   ``pip``, ``pytest``, ``git``, and others. ``ams misc --version`` is
   unchanged and still prints the multi-line dependency block (Python,
   andes, numpy, cvxpy, solvers) for bug reports
+- ``RParam.v``: pass scipy.sparse values through untouched on the
+  ``is_ext`` branch (caller-supplied ``v=...``). PR #233 fixed
+  ``MParam.v`` but missed this parallel path; now the no-auto-densify
+  contract is consistent across ``RParam`` and ``MParam``
+- ``NumOpDual.v0``: pass scipy.sparse outputs through untouched when
+  ``array_out=True``, mirroring the ``NumOp.v0`` fix from PR #233.
+  Previously sparse results were wrapped in a 1-element object-dtype
+  ``ndarray``, which broke downstream ``csr_matrix`` conversion. Audit
+  of all other ``v0`` overrides (``NumHstack``, ``ZonalSum``,
+  ``VarSelect``, ``VarReduction``, ``RampSub``) confirmed they all
+  construct results via numpy ops that already return ``ndarray``, so
+  no parallel fix was needed there
 - ``MParam.v`` no longer auto-densifies sparse-stored matrices on every
   property access. The underlying scipy.sparse object is now returned
   as-is; a new ``MParam.dense()`` method materializes a dense

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,6 +4,7 @@ import scipy.sparse as sps
 
 import ams
 from ams.core.matprocessor import MParam
+from ams.core.param import RParam
 from ams.core.service import NumOp, NumOpDual, ZonalSum
 
 
@@ -67,6 +68,23 @@ class TestService(unittest.TestCase):
                           fun=np.multiply, rfun=np.sum)
         self.assertEqual(p_sum.v, self.ss.PQ.p0.v.sum())
 
+    def test_NumOpDual_sparse_passthrough(self):
+        """
+        ``NumOpDual.v0`` should pass scipy.sparse outputs through
+        untouched when ``array_out=True``, mirroring the ``NumOp.v0``
+        contract from PR #233.
+        """
+        sm = sps.csr_matrix(np.eye(3))
+        u = MParam(v=sm)
+        u2 = MParam(v=sm)
+        op = NumOpDual(u=u, u2=u2,
+                       fun=lambda a, b: a + b,
+                       array_out=True)
+        # Sparse-in, sparse-out: must not be wrapped in an
+        # object-dtype ndarray as the pre-#233 NumOp bug used to do.
+        self.assertTrue(sps.issparse(op.v0))
+
+
     def test_ZonalSum(self):
         """
         Test `ZonalSum`.
@@ -79,3 +97,20 @@ class TestService(unittest.TestCase):
         np.testing.assert_array_equal(ds.v.shape, (self.nR, self.nD))
         # check if the values are correct
         self.assertTrue(np.all(ds.v.sum(axis=1) <= np.array([self.nB, self.nB])))
+
+
+class TestRParam(unittest.TestCase):
+    """
+    Test functionality of ``RParam``.
+    """
+
+    def test_RParam_sparse_passthrough(self):
+        """
+        Externally-supplied sparse values should flow through
+        ``RParam.v`` without being densified, completing the
+        no-auto-densify contract started by PR #233.
+        """
+        sm = sps.csr_matrix([[1, 0], [0, 2]])
+        rp = RParam(v=sm)
+        self.assertTrue(sps.issparse(rp.v))
+        np.testing.assert_array_equal(rp.v.toarray(), sm.toarray())

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -84,7 +84,6 @@ class TestService(unittest.TestCase):
         # object-dtype ndarray as the pre-#233 NumOp bug used to do.
         self.assertTrue(sps.issparse(op.v0))
 
-
     def test_ZonalSum(self):
         """
         Test `ZonalSum`.


### PR DESCRIPTION
## Summary

PR #233 stopped `MParam.v` from auto-densifying sparse-stored matrices, but two parallel paths were missed and continued to leak the old behavior. Both are pre-v1.2.1 blockers — without them, the v1.2.1 release notes would ship a half-applied "no auto-densify" promise.

**4a — `RParam.v` `is_ext` branch** (`ams/core/param.py`): drop the `.toarray()` call so caller-supplied sparse matrices (`RParam(v=some_sparse_matrix)`) flow through the same as `MParam.v` post-#233.

**4b — `NumOpDual.v0`** (`ams/core/service.py`): mirror the `NumOp.v0` pattern from PR #233 — wrap genuine Python scalars in a 1-element ndarray, pass ndarrays and `scipy.sparse` through untouched, convert other array-likes via `np.asarray`.

### Audit of remaining `v0` overrides

The plan suggested auditing all `v0`-overriding subclasses for the same bug. Result: only `NumOpDual` needed the fix. Each of the others either constructs its result via numpy ops that always return ndarray, or inherits from a now-fixed parent.

| Class | Outcome |
|-------|---------|
| `NumOp` | ✅ Fixed by PR #233 (reference pattern) |
| `NumOpDual` | 🔧 **Fixed in this PR** |
| `NumExpandDim` | No `v0` override; inherits from `NumOp` ✅ |
| `MinDur` | Overrides `v` (not `v0`); inherits `v0` from `NumOpDual` 🔧 (covered) |
| `NumHstack` | Calls `np.hstack(...)` — always ndarray |
| `ZonalSum` | Builds via `(row == col).astype(int)` — always ndarray |
| `VarSelect` | Builds via `meshgrid + ==` — always ndarray |
| `VarReduction` | Calls `self.fun(shape=...)` (e.g. `np.zeros`/`np.ones`) — always ndarray |
| `RampSub` | Builds via `np.eye - np.eye` — always ndarray |

## Tests

Two new tests in `tests/test_service.py`:
- `test_RParam_sparse_passthrough` — `RParam(v=csr_matrix)` returns the sparse matrix as-is.
- `test_NumOpDual_sparse_passthrough` — sparse-in / sparse-out through `NumOpDual` is not wrapped in an object-dtype ndarray.

## Test plan

- [x] `pytest tests/test_service.py -v` — 7 pass, including new tests
- [x] `pytest tests/` — 321 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)