### PR TITLE
Prepare for v1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ __pycache__/
 .idea/*
 
 # claude
-.claude/*
+.claude/
 
 # Sphinx documentation
 docs/source/modelref.rst

--- a/ams/cli.py
+++ b/ams/cli.py
@@ -34,7 +34,14 @@ def create_parser():
         Parser with all AMS options
     """
 
+    from ams import __version__
+
     parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {__version__}')
 
     parser.add_argument(
         '-v', '--verbose',

--- a/ams/cli.py
+++ b/ams/cli.py
@@ -36,7 +36,7 @@ def create_parser():
 
     from ams import __version__
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog='ams')
 
     parser.add_argument(
         '--version',

--- a/ams/cli.py
+++ b/ams/cli.py
@@ -8,6 +8,7 @@ import os
 import platform
 import sys
 from time import strftime
+from ams import __version__
 from ams.main import config_logger
 from ams.utils.paths import get_log_dir
 from ams.routines import routine_cli
@@ -33,8 +34,6 @@ def create_parser():
     argparse.ArgumentParser
         Parser with all AMS options
     """
-
-    from ams import __version__
 
     parser = argparse.ArgumentParser(prog='ams')
 

--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -578,8 +578,9 @@ class MatProcessor:
         PTDF[m, n] represents the increased line flow on line `m` for a 1 p.u. power injection at bus `n`.
         It is similar to the Generation Shift Factor (GSF).
 
-        For large cases, use `incremental=True` to calculate the sparse PTDF in chunks. In this mode, the
-        PTDF is calculated in chunks, and thus more memory friendly.
+        The reduced bus susceptance matrix is factorized once via :func:`scipy.sparse.linalg.splu`
+        and the factorization is reused across all line chunks; the dense full-`Bbus` solver path
+        used previously is removed because it materialized an `nb x nb` dense matrix.
 
         Parameters
         ----------
@@ -588,16 +589,19 @@ class MatProcessor:
         no_store : bool, optional
             If False, store the PTDF in `MatProcessor.PTDF._v`. Default is False.
         incremental : bool, optional
-            If True, calculate the sparse PTDF in chunks to save memory. Default is False.
+            Controls chunking of the right-hand side. If True, solve in chunks of size `step` to
+            cap peak memory; if False, solve all line rows at once (one chunk). The reduced bus
+            matrix is factored once in either mode. Default is False.
         step : int, optional
-            Step size for incremental calculation. Default is 1000.
+            RHS chunk size when `incremental=True`. Default is 1000.
         no_tqdm : bool, optional
             If True, disable the progress bar. Default is False.
         permc_spec : str, optional
-            Column permutation strategy for sparsity preservation. Default is 'COLAMD'.
+            Column permutation strategy passed to :func:`scipy.sparse.linalg.splu`. Default is None
+            (SuperLU's default, COLAMD).
         use_umfpack : bool, optional
-            If True, use UMFPACK as the solver. Effective only when (`incremental=True`)
-            & (`line` contains a single line or `step` is 1). Default is True.
+            Retained for backward compatibility; ignored. The factorization now uses SuperLU via
+            :func:`scipy.sparse.linalg.splu`, factored once and reused for all chunks.
 
         Returns
         -------
@@ -609,6 +613,8 @@ class MatProcessor:
         1. PowerWorld Documentation, Power Transfer Distribution Factors,
            https://www.powerworld.com/WebHelp/Content/MainDocumentation_HTML/Power_Transfer_Distribution_Factors.htm
         """
+        del use_umfpack  # accepted for API back-compat; see docstring
+
         system = self.system
 
         # use first slack bus as reference slack bus
@@ -645,28 +651,21 @@ class MatProcessor:
         Bbus = self.Bbus._v
         Bf = self.Bf._v
 
-        if incremental:
-            # initialize progress bar
-            pbar = _init_pbar(total=100, unit='%', no_tqdm=no_tqdm)
+        # factor the reduced bus susceptance matrix once and reuse across chunks
+        A = Bbus[np.ix_(noslack, noref)].T.tocsc()
+        lu = sps.linalg.splu(A, permc_spec=permc_spec)
 
-            H = sps.lil_matrix((nline, system.Bus.n))
+        chunk = step if incremental else nline
+        H = sps.lil_matrix((nline, nbus))
 
-            # NOTE: for PTDF, we are building rows by rows
-            for start in range(0, nline, step):
-                end = min(start + step, nline)
-                sol = sps.linalg.spsolve(A=Bbus[np.ix_(noslack, noref)].T,
-                                         b=Bf[np.ix_(luid[start:end], noref)].T,
-                                         permc_spec=permc_spec,
-                                         use_umfpack=use_umfpack).T
-                H[start:end, noslack] = sol
+        pbar = _init_pbar(total=100, unit='%', no_tqdm=no_tqdm)
 
-                _update_pbar(pbar, end, nline)
-
-        else:
-            H = sps.lil_matrix((nline, nbus))
-            sol = np.linalg.solve(Bbus.todense()[np.ix_(noslack, noref)].T,
-                                  Bf.todense()[np.ix_(luid, noref)].T).T
-            H[:, noslack] = sol
+        for start in range(0, nline, chunk):
+            end = min(start + chunk, nline)
+            rhs = np.asarray(Bf[np.ix_(luid[start:end], noref)].T.todense())
+            sol = lu.solve(rhs).T
+            H[start:end, noslack] = sol
+            _update_pbar(pbar, end, nline)
 
         # reshape results into 1D array if only one line
         if isinstance(line, (int, str)):

--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -616,8 +616,10 @@ class MatProcessor:
 
         Returns
         -------
-        PTDF : scipy.sparse.lil_matrix
-            Power transfer distribution factor.
+        PTDF : scipy.sparse.csr_matrix
+            Power transfer distribution factor. The result is built into a
+            ``lil_matrix`` for fast row-block assignment during the chunk
+            loop and frozen to ``csr_matrix`` before being returned.
 
         References
         ----------
@@ -706,7 +708,9 @@ class MatProcessor:
         It requires DC PTDF and Cft.
 
         For large cases where memory is a concern, use `incremental=True` to
-        calculate the sparse LODF in chunks in the format of scipy.sparse.lil_matrix.
+        calculate the sparse LODF in chunks. The result is assembled into a
+        ``lil_matrix`` for fast row-block assignment during the chunk loop
+        and frozen to ``csr_matrix`` before being returned.
 
         Parameters
         ----------
@@ -725,7 +729,7 @@ class MatProcessor:
 
         Returns
         -------
-        LODF : scipy.sparse.lil_matrix
+        LODF : scipy.sparse.csr_matrix
             Line outage distribution factor.
 
         References

--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 import numpy as np
 
-from ams.utils.func import safe_div
 from ams.utils.misc import elapsed
 
 from ams.opt import Param
@@ -367,8 +366,8 @@ class MatProcessor:
         on_gen_idx = [idx_gen[i] for i in on_gen]  # idx of online generators
         on_gen_bus = system.StaticGen.get(src='bus', attr='v', idx=on_gen_idx)
 
-        row = np.array([system.Bus.idx2uid(x) for x in on_gen_bus])
-        col = np.array([idx_gen.index(x) for x in on_gen_idx])
+        row = np.asarray(system.Bus.idx2uid(on_gen_bus))
+        col = np.asarray(system.StaticGen.idx2uid(on_gen_idx))
         self.Cg._v = sps.csr_matrix((np.ones(len(on_gen_idx)), (row, col)), (nb, ng))
         self.Cg.col_names = idx_gen
         self.Cg.row_names = system.Bus.idx.v
@@ -751,9 +750,13 @@ class MatProcessor:
         for luidi in luidp:
             H_chunk = ptdf @ self.Cft._v[:, luidi]
             h_chunk = H_chunk.diagonal(-luidi[0])
-            rden = safe_div(np.ones(H_chunk.shape),
-                            np.tile(np.ones_like(h_chunk) - h_chunk, (nbranch, 1)))
-            H_chunk = H_chunk.multiply(rden).tolil()
+            # column-scale: H_chunk[i, j] /= (1 - h_chunk[j]); preserves
+            # safe_div semantics by zeroing columns where (1 - h_chunk) == 0
+            denom = 1.0 - h_chunk
+            inv = np.zeros_like(denom)
+            mask = denom != 0
+            inv[mask] = 1.0 / denom[mask]
+            H_chunk = (H_chunk @ sps.diags(inv)).tolil()
             # NOTE: use lil_matrix to set diagonal values as -1
             rsid = sps.diags(H_chunk.diagonal(-luidi[0])) + sps.eye(H_chunk.shape[1])
             if H_chunk.shape[0] > rsid.shape[0]:

--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -595,7 +595,7 @@ class MatProcessor:
         step : int, optional
             RHS chunk size when `incremental=True`. Default is 1000.
         no_tqdm : bool, optional
-            If True, disable the progress bar. Default is False.
+            If True, disable the progress bar. Default is True.
         permc_spec : str, optional
             Column permutation strategy passed to :func:`scipy.sparse.linalg.splu`. Default is None
             (SuperLU's default, COLAMD).
@@ -653,7 +653,10 @@ class MatProcessor:
 
         # factor the reduced bus susceptance matrix once and reuse across chunks
         A = Bbus[np.ix_(noslack, noref)].T.tocsc()
-        lu = sps.linalg.splu(A, permc_spec=permc_spec)
+        if permc_spec is None:
+            lu = sps.linalg.splu(A)
+        else:
+            lu = sps.linalg.splu(A, permc_spec=permc_spec)
 
         chunk = step if incremental else nline
         H = sps.lil_matrix((nline, nbus))
@@ -662,7 +665,7 @@ class MatProcessor:
 
         for start in range(0, nline, chunk):
             end = min(start + chunk, nline)
-            rhs = np.asarray(Bf[np.ix_(luid[start:end], noref)].T.todense())
+            rhs = Bf[np.ix_(luid[start:end], noref)].T.toarray()
             sol = lu.solve(rhs).T
             H[start:end, noslack] = sol
             _update_pbar(pbar, end, nline)

--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -196,38 +196,50 @@ class MParam(Param):
                                           path=path,
                                           fmt='csv')
 
-        pd.DataFrame(data=self.v, columns=self.col_names, index=self.row_names).to_csv(path)
+        pd.DataFrame(data=self.dense(), columns=self.col_names, index=self.row_names).to_csv(path)
 
         return file_name
 
     @property
     def v(self):
         """
-        Return the value of the parameter.
+        Return the underlying value of the parameter.
+
+        For ``sparse=True`` MParams the underlying scipy.sparse matrix is
+        returned as-is. Use :meth:`dense` (or call ``.toarray()`` on the
+        sparse object directly) when an :class:`numpy.ndarray` is required.
         """
-        # NOTE: scipy.sparse matrix will return 2D array
-        # so we squeeze it here if only one row
-        if isinstance(self._v, (sps.csr_matrix, sps.lil_matrix, sps.csc_matrix)):
+        return self._v
+
+    def dense(self):
+        """
+        Return the parameter value as a dense :class:`numpy.ndarray`.
+
+        For sparse-stored MParams this materializes the full dense matrix
+        and squeezes a single-row result down to a 1D array (preserving
+        the historical 1-row shape contract). For dense storage this is
+        a no-op pass-through.
+        """
+        if sps.issparse(self._v):
             out = self._v.toarray()
             if out.shape[0] == 1:
                 return np.squeeze(out)
-            else:
-                return out
+            return out
         return self._v
 
     @property
     def shape(self):
         """
-        Return the shape of the parameter.
+        Return the shape of the parameter without materializing the value.
         """
-        return self.v.shape
+        return self._v.shape
 
     @property
     def n(self):
         """
-        Return the szie of the parameter.
+        Return the size of the parameter without materializing the value.
         """
-        return len(self.v)
+        return self._v.shape[0]
 
     @property
     def class_name(self):
@@ -658,6 +670,7 @@ class MatProcessor:
             lu = sps.linalg.splu(A, permc_spec=permc_spec)
 
         chunk = step if incremental else nline
+        # build with lil for fast row-block assignment, freeze to csr at the end
         H = sps.lil_matrix((nline, nbus))
 
         pbar = _init_pbar(total=100, unit='%', no_tqdm=no_tqdm)
@@ -668,6 +681,8 @@ class MatProcessor:
             sol = lu.solve(rhs).T
             H[start:end, noslack] = sol
             _update_pbar(pbar, end, nline)
+
+        H = H.tocsr()
 
         # reshape results into 1D array if only one line
         if isinstance(line, (int, str)):
@@ -768,6 +783,8 @@ class MatProcessor:
             LODF[:, [luid.index(i) for i in luidi]] = H_chunk
 
             _update_pbar(pbar, luid.index(luidi[-1]), nline)
+
+        LODF = LODF.tocsr()
 
         # reshape results into 1D array if only one line
         if isinstance(line, (int, str)):

--- a/ams/core/param.py
+++ b/ams/core/param.py
@@ -8,7 +8,6 @@ import logging
 from typing import Optional, Iterable
 
 import numpy as np
-from scipy.sparse import issparse
 
 from ams.opt import Param
 
@@ -173,10 +172,7 @@ class RParam(Param):
             raise NotImplementedError(msg)
         if self.indexer is None:
             if self.is_ext:
-                if issparse(self._v):
-                    out = self._v.toarray()
-                else:
-                    out = self._v
+                out = self._v
             elif self.is_group:
                 out = self.owner.get(src=self.src, attr='v',
                                      idx=self.owner.get_all_idxes())

--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -299,7 +299,9 @@ class NumOp(ROperationService):
     def v0(self):
         out = self.fun(self.u.v, **self.args)
         if self.array_out:
-            if not isinstance(out, np.ndarray):
+            # wrap genuine Python scalars in a 1-element ndarray; pass
+            # ndarrays and scipy.sparse matrices through untouched
+            if not isinstance(out, np.ndarray) and not spr.issparse(out):
                 out = np.array([out])
         return out
 

--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -450,8 +450,14 @@ class NumOpDual(NumOp):
     def v0(self):
         out = self.fun(self.u.v, self.u2.v, **self.args)
         if self.array_out:
-            if not isinstance(out, np.ndarray):
-                out = np.array([out])
+            # wrap genuine Python scalars in a 1-element ndarray; pass
+            # ndarrays and scipy.sparse matrices through untouched;
+            # convert other array-likes (lists/tuples) via np.asarray
+            if not isinstance(out, np.ndarray) and not spr.issparse(out):
+                if np.isscalar(out):
+                    out = np.array([out])
+                else:
+                    out = np.asarray(out)
         if self.sparse:
             return spr.csr_matrix(out)
         return out

--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -300,9 +300,13 @@ class NumOp(ROperationService):
         out = self.fun(self.u.v, **self.args)
         if self.array_out:
             # wrap genuine Python scalars in a 1-element ndarray; pass
-            # ndarrays and scipy.sparse matrices through untouched
+            # ndarrays and scipy.sparse matrices through untouched;
+            # convert other array-likes (lists/tuples) via np.asarray
             if not isinstance(out, np.ndarray) and not spr.issparse(out):
-                out = np.array([out])
+                if np.isscalar(out):
+                    out = np.array([out])
+                else:
+                    out = np.asarray(out)
         return out
 
     @property

--- a/ams/main.py
+++ b/ams/main.py
@@ -854,33 +854,44 @@ def selftest(quick=False, extra=False, **kwargs):
         )
         return
 
-    try:
+    # Suppress unittest's per-test prints by redirecting stdout to
+    # /dev/null. Save the caller's stdout (not ``sys.__stdout__``) so
+    # ``contextlib.redirect_stdout`` and similar wrappers survive, and
+    # restore + close in a ``finally`` so an exception inside discovery
+    # or the runner doesn't leak the file handle or leave stdout
+    # suppressed.
+    saved_stdout = sys.stdout
+    devnull = None
+    if logger.handlers:
         logger.handlers[0].setLevel(logging.WARNING)
-        sys.stdout = open(os.devnull, 'w')  # suppress print statements
-    except IndexError:  # logger not set up
-        pass
+        devnull = open(os.devnull, 'w')
+        sys.stdout = devnull
 
-    suite = unittest.TestLoader().discover(test_directory)
+    try:
+        suite = unittest.TestLoader().discover(test_directory)
 
-    # remove codegen for quick mode
-    for test_group in suite._tests:
-        for test_class in test_group._tests:
-            tests_keep = list()
+        # remove codegen for quick mode
+        for test_group in suite._tests:
+            for test_class in test_group._tests:
+                tests_keep = list()
 
-            if not hasattr(test_class, '_tests'):
-                continue
-            for t in test_class._tests:
-                # skip the extra tests if `extra` is not True
-                if (extra is not True) and (extra_test in t._testMethodName):
+                if not hasattr(test_class, '_tests'):
                     continue
+                for t in test_class._tests:
+                    # skip the extra tests if `extra` is not True
+                    if (extra is not True) and (extra_test in t._testMethodName):
+                        continue
 
-                # skip the ones for `quick`
-                if quick is True and (t._testMethodName in quick_skips):
-                    continue
+                    # skip the ones for `quick`
+                    if quick is True and (t._testMethodName in quick_skips):
+                        continue
 
-                tests_keep.append(t)
+                    tests_keep.append(t)
 
-            test_class._tests = tests_keep
+                test_class._tests = tests_keep
 
-    unittest.TextTestRunner(verbosity=verbose).run(suite)
-    sys.stdout = sys.__stdout__
+        unittest.TextTestRunner(verbosity=verbose).run(suite)
+    finally:
+        sys.stdout = saved_stdout
+        if devnull is not None:
+            devnull.close()

--- a/ams/main.py
+++ b/ams/main.py
@@ -840,14 +840,26 @@ def selftest(quick=False, extra=False, **kwargs):
     # extra test naming convention
     extra_test = 'extra_test'
 
+    # The test suite ships with the source tree but is excluded from the
+    # built wheel (see ``[tool.setuptools.packages.find].exclude`` in
+    # pyproject.toml). On a wheel install ``tests_root()`` therefore
+    # points at a directory that does not exist; degrade gracefully
+    # instead of crashing inside unittest discovery.
+    test_directory = tests_root()
+    if not os.path.isdir(test_directory):
+        logger.warning(
+            "ams st: test suite is not packaged with wheel installs. "
+            "Clone https://github.com/CURENT/ams and run 'pytest' from "
+            "the repository root for the full suite."
+        )
+        return
+
     try:
         logger.handlers[0].setLevel(logging.WARNING)
         sys.stdout = open(os.devnull, 'w')  # suppress print statements
     except IndexError:  # logger not set up
         pass
 
-    # discover test cases
-    test_directory = tests_root()
     suite = unittest.TestLoader().discover(test_directory)
 
     # remove codegen for quick mode

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -14,6 +14,14 @@ v1.2.1 (unreleased)
 
 **Improvements:**
 
+- ``MatProcessor.build_lodf``: replace the dense ``np.ones`` + ``np.tile``
+  column-broadcast inside the chunk loop with sparse column scaling via
+  ``sps.diags(1 / (1 - h_chunk))``. Removes a transient
+  ``nbranch × step`` dense allocation that reached ~1 GB on
+  ~70k-bus grids. Numerical output is unchanged.
+- ``MatProcessor.build_cg``: replace the O(ng²) ``list.index`` lookup
+  with ``StaticGen.idx2uid`` for O(ng) total cost. Matters as
+  generator counts grow; modest at current case sizes.
 - ``MatProcessor.build_ptdf``: factorize the reduced bus susceptance
   matrix once via :func:`scipy.sparse.linalg.splu` and reuse the
   factorization across all line chunks. Removes the dense full-``Bbus``

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -19,6 +19,18 @@ v1.2.1 (unreleased)
   ``pip``, ``pytest``, ``git``, and others. ``ams misc --version`` is
   unchanged and still prints the multi-line dependency block (Python,
   andes, numpy, cvxpy, solvers) for bug reports
+- ``RParam.v``: pass scipy.sparse values through untouched on the
+  ``is_ext`` branch (caller-supplied ``v=...``). PR #233 fixed
+  ``MParam.v`` but missed this parallel path; now the no-auto-densify
+  contract is consistent across ``RParam`` and ``MParam``
+- ``NumOpDual.v0``: pass scipy.sparse outputs through untouched when
+  ``array_out=True``, mirroring the ``NumOp.v0`` fix from PR #233.
+  Previously sparse results were wrapped in a 1-element object-dtype
+  ``ndarray``, which broke downstream ``csr_matrix`` conversion. Audit
+  of all other ``v0`` overrides (``NumHstack``, ``ZonalSum``,
+  ``VarSelect``, ``VarReduction``, ``RampSub``) confirmed they all
+  construct results via numpy ops that already return ``ndarray``, so
+  no parallel fix was needed there
 - ``MParam.v`` no longer auto-densifies sparse-stored matrices on every
   property access. The underlying scipy.sparse object is now returned
   as-is; a new ``MParam.dense()`` method materializes a dense

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -14,6 +14,25 @@ v1.2.1 (unreleased)
 
 **Improvements:**
 
+- ``MParam.v`` no longer auto-densifies sparse-stored matrices on every
+  property access. The underlying scipy.sparse object is now returned
+  as-is; a new ``MParam.dense()`` method materializes a dense
+  :class:`numpy.ndarray` when one is genuinely required. ``.shape`` and
+  ``.n`` consult the underlying value directly without densifying.
+  Together with the ``sparse=True`` declarations on the matrix
+  ``RParam`` consumers in ``DCPF`` / ``DCOPF`` / ``DCOPF2``, this lets
+  routines actually pass sparse matrices to CVXPY instead of silently
+  densifying them on every parameter set
+- ``MatProcessor.build_ptdf`` / ``build_lodf`` now finalize the result
+  as ``csr_matrix`` rather than leaving it as ``lil_matrix``. ``lil`` is
+  the right format for incremental row assignment during construction
+  but is poorly supported by downstream consumers (CVXPY, scipy ``COO``
+  conversion); freezing to ``csr`` at the end is the canonical pattern
+- ``NumOp.v0``: pass scipy.sparse outputs through untouched when
+  ``array_out=True``. Previously sparse results were wrapped in a
+  1-element :class:`numpy.ndarray` of object dtype, which broke the
+  subsequent ``csr_matrix`` conversion in :meth:`NumOp.v` for sparse
+  ``NumOp``\ s such as ``DCOPF2.PTDFt``
 - ``MatProcessor.build_lodf``: replace the dense ``np.ones`` + ``np.tile``
   column-broadcast inside the chunk loop with sparse column scaling
   that divides each column by ``(1 - h_chunk[j])``, zeroing columns

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -21,7 +21,12 @@ v1.2.1 (unreleased)
   crashing with ``ImportError: Start directory is not importable``. The
   command now detects the missing directory, logs a one-line message
   pointing the user to ``pytest`` from a clone, and exits cleanly. From
-  a source clone the behavior is unchanged
+  a source clone the behavior is unchanged. While in the function,
+  also harden the stdout-suppression block: save the caller's stdout
+  (not ``sys.__stdout__``) so wrappers like
+  ``contextlib.redirect_stdout`` are preserved, restore + close the
+  ``/dev/null`` handle in a ``finally``, and gate the redirect on
+  ``logger.handlers`` being non-empty (replacing a try/except IndexError)
 
 **Improvements:**
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -21,7 +21,7 @@ v1.2.1 (unreleased)
   unusable on grids beyond a few thousand buses. Large-case PTDF builds
   are noticeably faster (e.g. ~2.5× on a 2000-bus case in incremental
   mode); numerical output is unchanged. The ``use_umfpack`` keyword is
-  retained for backward compatibility but is now a no-op
+  retained for backward compatibility but is now a no-op.
 
 v1.2.0 (2026-04-23)
 ----------------------

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -9,6 +9,20 @@ The APIs before v3.0.0 are in beta and may change without prior notice.
 v1.2
 ==========
 
+v1.2.1 (unreleased)
+----------------------
+
+**Improvements:**
+
+- ``MatProcessor.build_ptdf``: factorize the reduced bus susceptance
+  matrix once via :func:`scipy.sparse.linalg.splu` and reuse the
+  factorization across all line chunks. Removes the dense full-``Bbus``
+  solver path, which materialized an ``nb × nb`` dense matrix and was
+  unusable on grids beyond a few thousand buses. Large-case PTDF builds
+  are noticeably faster (e.g. ~2.5× on a 2000-bus case in incremental
+  mode); numerical output is unchanged. The ``use_umfpack`` keyword is
+  retained for backward compatibility but is now a no-op
+
 v1.2.0 (2026-04-23)
 ----------------------
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -12,6 +12,17 @@ v1.2
 v1.2.1 (unreleased)
 ----------------------
 
+**Bug fixes:**
+
+- ``ams st`` (a.k.a. ``ams.main.selftest``) now degrades gracefully on
+  wheel installs. v1.2.0 correctly excluded the ``tests/`` directory
+  from the built wheel, but ``ams st`` was still calling
+  ``unittest.TestLoader().discover('<site-packages>/tests')`` and
+  crashing with ``ImportError: Start directory is not importable``. The
+  command now detects the missing directory, logs a one-line message
+  pointing the user to ``pytest`` from a clone, and exits cleanly. From
+  a source clone the behavior is unchanged
+
 **Improvements:**
 
 - Add top-level ``ams --version`` flag that prints the AMS version

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -9,7 +9,7 @@ The APIs before v3.0.0 are in beta and may change without prior notice.
 v1.2
 ==========
 
-v1.2.1 (unreleased)
+v1.2.1 (2026-04-29)
 ----------------------
 
 **Bug fixes:**

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -15,10 +15,11 @@ v1.2.1 (unreleased)
 **Improvements:**
 
 - ``MatProcessor.build_lodf``: replace the dense ``np.ones`` + ``np.tile``
-  column-broadcast inside the chunk loop with sparse column scaling via
-  ``sps.diags(1 / (1 - h_chunk))``. Removes a transient
-  ``nbranch × step`` dense allocation that reached ~1 GB on
-  ~70k-bus grids. Numerical output is unchanged.
+  column-broadcast inside the chunk loop with sparse column scaling
+  that divides each column by ``(1 - h_chunk[j])``, zeroing columns
+  where the denominator is zero to preserve the prior ``safe_div``
+  behavior. Removes a transient ``nbranch × step`` dense allocation
+  that reached ~1 GB on ~70k-bus grids. Numerical output is unchanged.
 - ``MatProcessor.build_cg``: replace the O(ng²) ``list.index`` lookup
   with ``StaticGen.idx2uid`` for O(ng) total cost. Matters as
   generator counts grow; modest at current case sizes.

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -14,6 +14,11 @@ v1.2.1 (unreleased)
 
 **Improvements:**
 
+- Add top-level ``ams --version`` flag that prints the AMS version
+  (``ams X.Y.Z``), following the standard CLI convention used by
+  ``pip``, ``pytest``, ``git``, and others. ``ams misc --version`` is
+  unchanged and still prints the multi-line dependency block (Python,
+  andes, numpy, cvxpy, solvers) for bug reports
 - ``MParam.v`` no longer auto-densifies sparse-stored matrices on every
   property access. The underlying scipy.sparse object is now returned
   as-is; a new ``MParam.dense()`` method materializes a dense

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,12 @@ class TestCLI(unittest.TestCase):
     def test_cli_parser(self):
         ams.cli.create_parser()
 
+    def test_cli_version_flag(self):
+        parser = ams.cli.create_parser()
+        with self.assertRaises(SystemExit) as cm:
+            parser.parse_args(['--version'])
+        self.assertEqual(cm.exception.code, 0)
+
     def test_cli_preamble(self):
         ams.cli.preamble()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
-import unittest
+import contextlib
+import io
 import os
+import unittest
 
+import ams
 import ams.main
 import ams.cli
 
@@ -12,9 +15,13 @@ class TestCLI(unittest.TestCase):
 
     def test_cli_version_flag(self):
         parser = ams.cli.create_parser()
-        with self.assertRaises(SystemExit) as cm:
-            parser.parse_args(['--version'])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with self.assertRaises(SystemExit) as cm:
+                parser.parse_args(['--version'])
         self.assertEqual(cm.exception.code, 0)
+        out = buf.getvalue().strip()
+        self.assertEqual(out, f'ams {ams.__version__}')
 
     def test_cli_preamble(self):
         ams.cli.preamble()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 import contextlib
 import io
 import os
+import sys
 import unittest
+from unittest import mock
 
 import ams
 import ams.main
@@ -36,6 +38,22 @@ class TestCLI(unittest.TestCase):
     def test_misc(self):
         ams.main.misc(show_license=True)
         ams.main.misc(save_config=None, overwrite=True)
+
+    def test_selftest_missing_tests_dir(self):
+        """
+        ``ams st`` must degrade gracefully when the external ``tests/``
+        directory is absent — the wheel excludes it from packaging, so
+        a wheel install would otherwise crash inside unittest discovery.
+        """
+        stdout_before = sys.stdout
+        with mock.patch.object(ams.main, 'tests_root',
+                               return_value='/nonexistent/ams/tests'):
+            with self.assertLogs('ams.main', level='WARNING') as cm:
+                self.assertIsNone(ams.main.selftest())
+        self.assertTrue(any('not packaged with wheel' in m for m in cm.output),
+                        msg=f'unexpected log output: {cm.output}')
+        # stdout must not be left redirected on the graceful-skip path.
+        self.assertIs(sys.stdout, stdout_before)
 
     def test_profile_run(self):
         _ = ams.main.run(ams.get_case('matpower/case5.m'),

--- a/tests/test_matp.py
+++ b/tests/test_matp.py
@@ -134,34 +134,41 @@ class TestMatProcessorBasic(unittest.TestCase):
         one_vec = MParam(v=sps.csr_matrix(np.ones(self.ss.Bus.n)))
         # check if `_v` is `sps.csr_matrix` instance
         self.assertIsInstance(one_vec._v, sps.csr_matrix)
-        # check if `v` is 1D-array
-        self.assertEqual(one_vec.v.shape, (self.ss.Bus.n,))
+        # `.v` returns the underlying sparse object as-is; `.dense()`
+        # squeezes a 1-row sparse to a 1D ndarray
+        self.assertTrue(sps.issparse(one_vec.v))
+        self.assertEqual(one_vec.dense().shape, (self.ss.Bus.n,))
 
     def test_c(self):
         """
-        Test connectivity matrices.
+        Test connectivity matrices. `.v` returns the underlying sparse
+        object; `.dense()` materializes a dense ndarray.
         """
         # Test `Cg`
         self.assertIsInstance(self.mats.Cg._v, (sps.csr_matrix, sps.lil_matrix))
-        self.assertIsInstance(self.mats.Cg.v, np.ndarray)
+        self.assertTrue(sps.issparse(self.mats.Cg.v))
+        self.assertIsInstance(self.mats.Cg.dense(), np.ndarray)
         self.assertEqual(self.mats.Cg._v.max(), 1)
         np.testing.assert_equal(self.mats.Cg._v.sum(axis=0), np.ones((1, self.ng)))
 
         # Test `Cl`
         self.assertIsInstance(self.mats.Cl._v, (sps.csr_matrix, sps.lil_matrix))
-        self.assertIsInstance(self.mats.Cl.v, np.ndarray)
+        self.assertTrue(sps.issparse(self.mats.Cl.v))
+        self.assertIsInstance(self.mats.Cl.dense(), np.ndarray)
         self.assertEqual(self.mats.Cl._v.max(), 1)
         np.testing.assert_equal(self.mats.Cl._v.sum(axis=0), np.ones((1, self.nD)))
 
         # Test `Csh`
         self.assertIsInstance(self.mats.Csh._v, (sps.csr_matrix, sps.lil_matrix))
-        self.assertIsInstance(self.mats.Csh.v, np.ndarray)
+        self.assertTrue(sps.issparse(self.mats.Csh.v))
+        self.assertIsInstance(self.mats.Csh.dense(), np.ndarray)
         self.assertEqual(self.mats.Csh._v.max(), 1)
         np.testing.assert_equal(self.mats.Csh._v.sum(axis=0), np.ones((1, self.nsh)))
 
         # Test `Cft`
         self.assertIsInstance(self.mats.Cft._v, (sps.csr_matrix, sps.lil_matrix))
-        self.assertIsInstance(self.mats.Cft.v, np.ndarray)
+        self.assertTrue(sps.issparse(self.mats.Cft.v))
+        self.assertIsInstance(self.mats.Cft.dense(), np.ndarray)
         self.assertEqual(self.mats.Cft._v.max(), 1)
         np.testing.assert_equal(self.mats.Cft._v.sum(axis=0), np.zeros((1, self.nl)))
 
@@ -260,7 +267,7 @@ class TestBuildPTDF(unittest.TestCase):
                                           no_tqdm=True)
         np.testing.assert_array_almost_equal(ptdf_l2.todense(),
                                              self.ptdf_full[[2], :])
-        self.assertTrue(sps.isspmatrix_lil(ptdf_l2))
+        self.assertTrue(sps.issparse(ptdf_l2))
         self.assertIsNone(self.ss.mats.PTDF._v)
 
         # input list with single element
@@ -269,7 +276,7 @@ class TestBuildPTDF(unittest.TestCase):
                                            no_tqdm=False)
         np.testing.assert_array_almost_equal(ptdf_l2p.todense(),
                                              self.ptdf_full[[2], :])
-        self.assertTrue(sps.isspmatrix_lil(ptdf_l2p))
+        self.assertTrue(sps.issparse(ptdf_l2p))
         self.assertIsNone(self.ss.mats.PTDF._v)
 
         # input list with multiple elements
@@ -277,7 +284,7 @@ class TestBuildPTDF(unittest.TestCase):
                                            incremental=True, no_store=False)
         np.testing.assert_array_almost_equal(ptdf_l23.todense(),
                                              self.ptdf_full[2:4, :])
-        self.assertTrue(sps.isspmatrix_lil(ptdf_l23))
+        self.assertTrue(sps.issparse(ptdf_l23))
 
     def test_ptdf_incremental_step(self):
         """
@@ -286,7 +293,7 @@ class TestBuildPTDF(unittest.TestCase):
         # step < line length
         ptdf_c1 = self.ss.mats.build_ptdf(line=self.ss.Line.idx.v[2:4], incremental=True,
                                           no_store=False, step=1)
-        self.assertTrue(sps.isspmatrix_lil(ptdf_c1))
+        self.assertTrue(sps.issparse(ptdf_c1))
         self.assertIsNone(self.ss.mats.PTDF._v)
         np.testing.assert_array_almost_equal(ptdf_c1.todense(),
                                              self.ptdf_full[2:4, :],)
@@ -294,7 +301,7 @@ class TestBuildPTDF(unittest.TestCase):
         # step = line length
         ptdf_c2 = self.ss.mats.build_ptdf(line=self.ss.Line.idx.v[2:4], incremental=True,
                                           no_store=False, step=2)
-        self.assertTrue(sps.isspmatrix_lil(ptdf_c2))
+        self.assertTrue(sps.issparse(ptdf_c2))
         self.assertIsNone(self.ss.mats.PTDF._v)
         np.testing.assert_array_almost_equal(ptdf_c2.todense(),
                                              self.ptdf_full[2:4, :],)
@@ -302,7 +309,7 @@ class TestBuildPTDF(unittest.TestCase):
         # step > line length
         ptdf_c5 = self.ss.mats.build_ptdf(line=self.ss.Line.idx.v[2:4], incremental=True,
                                           no_store=False, step=5)
-        self.assertTrue(sps.isspmatrix_lil(ptdf_c5))
+        self.assertTrue(sps.issparse(ptdf_c5))
         self.assertIsNone(self.ss.mats.PTDF._v)
         np.testing.assert_array_almost_equal(ptdf_c5.todense(),
                                              self.ptdf_full[2:4, :],)
@@ -366,14 +373,14 @@ class TestBuildLODF(unittest.TestCase):
         np.testing.assert_array_almost_equal(lodf_l2.todense(),
                                              self.lodf_full[:, [2]],
                                              decimal=self.dec)
-        self.assertTrue(sps.isspmatrix_lil(lodf_l2))
+        self.assertTrue(sps.issparse(lodf_l2))
 
         # input list with single element
         lodf_l2p = self.ss.mats.build_lodf(line=[self.ss.Line.idx.v[2]], incremental=True, no_store=False)
         np.testing.assert_array_almost_equal(lodf_l2p.todense(),
                                              self.lodf_full[:, [2]],
                                              decimal=self.dec)
-        self.assertTrue(sps.isspmatrix_lil(lodf_l2p))
+        self.assertTrue(sps.issparse(lodf_l2p))
 
         # input list with multiple elements
         lodf_l23 = self.ss.mats.build_lodf(line=self.ss.Line.idx.v[2:4], incremental=True, no_store=False)
@@ -389,7 +396,7 @@ class TestBuildLODF(unittest.TestCase):
         lodf_c1 = self.ss.mats.build_lodf(line=self.ss.Line.idx.v[2:4],
                                           incremental=True,
                                           no_store=False, step=1)
-        self.assertTrue(sps.isspmatrix_lil(lodf_c1))
+        self.assertTrue(sps.issparse(lodf_c1))
         np.testing.assert_array_almost_equal(lodf_c1.todense(),
                                              self.lodf_full[:, 2:4],
                                              decimal=self.dec)
@@ -398,7 +405,7 @@ class TestBuildLODF(unittest.TestCase):
         lodf_c2 = self.ss.mats.build_lodf(line=self.ss.Line.idx.v[2:4],
                                           incremental=True,
                                           no_store=False, step=2)
-        self.assertTrue(sps.isspmatrix_lil(lodf_c2))
+        self.assertTrue(sps.issparse(lodf_c2))
         np.testing.assert_array_almost_equal(lodf_c2.todense(),
                                              self.lodf_full[:, 2:4],
                                              decimal=self.dec)
@@ -407,7 +414,7 @@ class TestBuildLODF(unittest.TestCase):
         lodf_c5 = self.ss.mats.build_lodf(line=self.ss.Line.idx.v[2:4],
                                           incremental=True,
                                           no_store=False, step=5)
-        self.assertTrue(sps.isspmatrix_lil(lodf_c5))
+        self.assertTrue(sps.issparse(lodf_c5))
         np.testing.assert_array_almost_equal(lodf_c5.todense(),
                                              self.lodf_full[:, 2:4],
                                              decimal=self.dec)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,6 +4,7 @@ import scipy.sparse as sps
 
 import ams
 from ams.core.matprocessor import MParam
+from ams.core.param import RParam
 from ams.core.service import NumOp, NumOpDual, ZonalSum
 
 
@@ -67,6 +68,23 @@ class TestService(unittest.TestCase):
                           fun=np.multiply, rfun=np.sum)
         self.assertEqual(p_sum.v, self.ss.PQ.p0.v.sum())
 
+    def test_NumOpDual_sparse_passthrough(self):
+        """
+        ``NumOpDual.v0`` should pass scipy.sparse outputs through
+        untouched when ``array_out=True``, mirroring the ``NumOp.v0``
+        contract from PR #233.
+        """
+        sm = sps.csr_matrix(np.eye(3))
+        u = MParam(v=sm)
+        u2 = MParam(v=sm)
+        op = NumOpDual(u=u, u2=u2,
+                       fun=lambda a, b: a + b,
+                       array_out=True)
+        # Sparse-in, sparse-out: must not be wrapped in an
+        # object-dtype ndarray as the pre-#233 NumOp bug used to do.
+        self.assertTrue(sps.issparse(op.v0))
+
+
     def test_ZonalSum(self):
         """
         Test `ZonalSum`.
@@ -79,3 +97,20 @@ class TestService(unittest.TestCase):
         np.testing.assert_array_equal(ds.v.shape, (self.nR, self.nD))
         # check if the values are correct
         self.assertTrue(np.all(ds.v.sum(axis=1) <= np.array([self.nB, self.nB])))
+
+
+class TestRParam(unittest.TestCase):
+    """
+    Test functionality of ``RParam``.
+    """
+
+    def test_RParam_sparse_passthrough(self):
+        """
+        Externally-supplied sparse values should flow through
+        ``RParam.v`` without being densified, completing the
+        no-auto-densify contract started by PR #233.
+        """
+        sm = sps.csr_matrix([[1, 0], [0, 2]])
+        rp = RParam(v=sm)
+        self.assertTrue(sps.issparse(rp.v))
+        np.testing.assert_array_equal(rp.v.toarray(), sm.toarray())

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -84,7 +84,6 @@ class TestService(unittest.TestCase):
         # object-dtype ndarray as the pre-#233 NumOp bug used to do.
         self.assertTrue(sps.issparse(op.v0))
 
-
     def test_ZonalSum(self):
         """
         Test `ZonalSum`.

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,7 +8,7 @@ from ams.core.service import NumOp, NumOpDual, ZonalSum
 
 
 def _as_dense(x):
-    """Return a dense ndarray view of either a sparse or dense input."""
+    """Return a dense ndarray from either a sparse or dense input."""
     return x.toarray() if sps.issparse(x) else np.asarray(x)
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,9 +1,15 @@
 import unittest
 import numpy as np
+import scipy.sparse as sps
 
 import ams
 from ams.core.matprocessor import MParam
 from ams.core.service import NumOp, NumOpDual, ZonalSum
+
+
+def _as_dense(x):
+    """Return a dense ndarray view of either a sparse or dense input."""
+    return x.toarray() if sps.issparse(x) else np.asarray(x)
 
 
 class TestService(unittest.TestCase):
@@ -25,14 +31,16 @@ class TestService(unittest.TestCase):
         Test `NumOp` without return function.
         """
         CftT = NumOp(u=self.ss.mats.Cft, fun=np.transpose)
-        np.testing.assert_array_equal(CftT.v.transpose(), self.ss.mats.Cft.v)
+        np.testing.assert_array_equal(_as_dense(CftT.v).transpose(),
+                                      self.ss.mats.Cft.dense())
 
     def test_NumOp_rfun(self):
         """
         Test `NumOp` with return function.
         """
         CftTT = NumOp(u=self.ss.mats.Cft, fun=np.transpose, rfun=np.transpose)
-        np.testing.assert_array_equal(CftTT.v, self.ss.mats.Cft.v)
+        np.testing.assert_array_equal(_as_dense(CftTT.v),
+                                      self.ss.mats.Cft.dense())
 
     def test_NumOp_ArrayOut(self):
         """


### PR DESCRIPTION
## Summary

Cut PR for **v1.2.1** — bundles all v1.2.1 patch-collector items merged into `develop` since v1.2.0 (2026-04-23). Opening this PR exercises CI on the master-bound merge before the tag push, per the project's release workflow.

## What's in v1.2.1

**Bug fixes:**
- **#237** (`cdc134ce`) — `ams st` degrades gracefully on wheel installs. v1.2.0 correctly excluded `tests/` from the wheel; `ams.main.selftest()` now detects the missing directory, logs a one-line directional message pointing to `pytest` from a clone, and exits cleanly. Source-clone path unchanged. Includes hardening of the surrounding stdout-suppression block (try/finally, caller-stdout preservation, `os.devnull` handle close).

**Improvements:**
- **#235** (`1b14ad66`) — top-level `ams --version` flag (`ams X.Y.Z`), matching `pip` / `pytest` / `git` convention. `ams misc --version` is unchanged and still emits the multi-line dependency block for bug reports.
- **#236** (`4358e878`) — sparse-densify carry-forwards from PR #233:
  - `RParam.v` `is_ext` branch no longer auto-densifies caller-supplied scipy.sparse values.
  - `NumOpDual.v0` mirrors the `NumOp.v0` pass-through fix; sparse outputs stay sparse when `array_out=True`.
  - Audit of remaining `v0` overrides (`NumHstack`, `ZonalSum`, `VarSelect`, `VarReduction`, `RampSub`) confirmed none needed parallel patches.

**Performance:**
- **#231** (`40f21931`) — `MatProcessor.build_ptdf`: factorize the reduced bus susceptance matrix once via `scipy.sparse.linalg.splu` and reuse across line chunks. Drops the dense `Bbus` solver path (was unusable beyond a few thousand buses). 2.46× wall-clock improvement on `case_ACTIVSg2000` incremental(step=500).
- **#232** (`3cb2ddc1`) — `MatProcessor.build_lodf` and `build_cg` cleanups: replace dense `np.ones`+`np.tile` column broadcast with sparse column scaling (~1 GB transient saving on ~70k-bus grids); replace O(ng²) `list.index` with `StaticGen.idx2uid`.
- **#233** (`fc053520`) — `MParam.v` no longer auto-densifies sparse-stored matrices on every property access; new `MParam.dense()` materializes when needed. Adjacent fixes: `build_ptdf` / `build_lodf` finalize as `csr_matrix` (was `lil_matrix`); `NumOp.v0` passes scipy.sparse through untouched. End-to-end effect: sparse actually flows to CVXPY as the routines always declared.

## Test plan

- [ ] CI green on develop→master (the whole point of this PR)
- [ ] After merge: tag `v1.2.1` on master and push to trigger `publish-pypi.yml`
- [ ] Post-cut: feedstock follow-up — swap `ams misc --version` → `ams --version` in the regro recipe-bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)