### PR TITLE
chore: silence Codacy Bandit findings via inline #nosec

### DIFF
--- a/ams/bench/env.py
+++ b/ams/bench/env.py
@@ -11,7 +11,7 @@ import importlib.metadata as importlib_metadata
 import logging
 import os
 import platform
-import subprocess
+import subprocess  # nosec B404 — env-capture only; no untrusted input. See pyproject.toml [tool.bandit].
 import sys
 from pathlib import Path
 from typing import Iterable
@@ -100,7 +100,7 @@ def _cpu_brand() -> str:
             logger.debug("bench env: /proc/cpuinfo read failed: %s", exc)
     # macOS: sysctl
     try:
-        out = subprocess.run(
+        out = subprocess.run(  # nosec B603 — literal argv, no shell, no user input
             ["sysctl", "-n", "machdep.cpu.brand_string"],
             capture_output=True, text=True, timeout=5,
         )
@@ -115,7 +115,7 @@ def _cpu_brand() -> str:
 def _git_info() -> tuple[str | None, bool | None]:
     """Return (short sha, dirty flag). Both ``None`` if not in a git repo."""
     try:
-        sha_res = subprocess.run(
+        sha_res = subprocess.run(  # nosec B603 — literal argv, no shell, no user input
             ["git", "rev-parse", "--short=10", "HEAD"],
             capture_output=True, text=True, timeout=5,
         )
@@ -123,7 +123,7 @@ def _git_info() -> tuple[str | None, bool | None]:
             return None, None
         sha = sha_res.stdout.strip()
 
-        dirty_res = subprocess.run(
+        dirty_res = subprocess.run(  # nosec B603 — literal argv, no shell, no user input
             ["git", "status", "--porcelain"],
             capture_output=True, text=True, timeout=5,
         )

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -9,6 +9,19 @@ The APIs before v3.0.0 are in beta and may change without prior notice.
 v1.2
 ==========
 
+v1.2.2 (unreleased)
+----------------------
+
+**Internal:**
+
+- Silence Codacy's Bandit findings on the env-capture subprocess calls
+  in ``ams/bench/env.py`` via per-call ``# nosec B404``/``# nosec B603``
+  markers. Codacy's Bandit engine doesn't honor the
+  ``[tool.bandit] skips`` block in ``pyproject.toml`` (it only passes a
+  config file when the project's pattern set is empty), so the inline
+  markers are what actually applies on Codacy. Local ``bandit -c
+  pyproject.toml`` runs continue to honor the skips list.
+
 v1.2.1 (2026-04-29)
 ----------------------
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -19,7 +19,7 @@ v1.2.2 (unreleased)
   markers. Codacy's Bandit engine doesn't honor the
   ``[tool.bandit] skips`` block in ``pyproject.toml`` (it only passes a
   config file when the project's pattern set is empty), so the inline
-  markers are what actually applies on Codacy. Local ``bandit -c
+  markers are what actually apply on Codacy. Local ``bandit -c
   pyproject.toml`` runs continue to honor the skips list.
 
 v1.2.1 (2026-04-29)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,14 @@ license-files = []
 # capture (`sysctl` for CPU brand, `git rev-parse`/`git status` for SHA
 # + dirty flag) with literal list args — no shell, no user-controlled
 # input. B110 (try/except/pass) is NOT skipped so real swallowed errors
-# stay visible. Codacy honors this section when running Bandit.
+# stay visible.
+#
+# Honored by local `bandit -c pyproject.toml -r ams` runs. NOT honored
+# by Codacy: codacy-bandit only passes a config file to bandit when the
+# project's pattern set is empty, and we leave the default Codacy
+# patterns enabled. The per-call `# nosec B404` / `# nosec B603`
+# comments in `ams/bench/env.py` are what actually silence these on
+# Codacy.
 skips = ["B404", "B603"]
 
 [tool.pydocstyle]


### PR DESCRIPTION
## Summary

- Codacy's Bandit engine ignores `pyproject.toml [tool.bandit] skips` because `codacy-bandit` only passes `-c <config>` to Bandit when the project's pattern set is empty — and AMS keeps the default Codacy patterns on.
- Add per-call `# nosec B404` / `# nosec B603` markers on the four env-capture subprocess sites in `ams/bench/env.py` (literal argv, no shell, no user input). These are honored by Codacy regardless of pattern config.
- Update the misleading comment on `[tool.bandit]` in `pyproject.toml` (was: "Codacy honors this section"; now documents that local-only honoring + the inline markers as the Codacy-side mechanism).
- Add a `v1.2.2 (unreleased)` section in release-notes describing the change.

This is **PR 1 of 2** for the post-v1.2.0 Codacy cleanup. PR 2 (`chore/codacy-cleanup-post-v1.2.0`) will follow with the real fixes (lazyimport `except ImportError`, `unspecified-encoding`, etc.) plus bulk Prospector suppressions.

Findings before this PR (from Codacy on PR #228 commit `d96f263d`): 3× Bandit B603 + 1× Bandit B404 on `ams/bench/env.py`. After: 0 of these on the next PR/commit run (verified locally with `bandit 1.9.4`).

## Test plan

- [x] `bandit -c pyproject.toml -r ams/bench/env.py` — no B404/B603/B607 (local config still honored)
- [x] `bandit -r ams/bench/env.py` (Codacy-equivalent, no `-c`) — B404/B603 skipped via `# nosec`; only B607 remains, which Codacy doesn't have enabled
- [ ] Verify on Codacy after PR opens that the 4 Bandit findings are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)