### PR TITLE
chore: post-v1.2.0 Codacy cleanup — real fixes + bulk pylint suppressions

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -10,3 +10,34 @@ pydocstyle:
   disable:
     - D203  # "1 blank line required before class docstring" — conflicts with D211
     - D213  # "Multi-line docstring summary should start at second line" — conflicts with D212
+
+pylint:
+  # Bulk-suppress pylint patterns that produce false-positive churn on
+  # AMS's long-standing code without flagging real defects:
+  #   - too-many-arguments / -positional-arguments / -locals / -branches:
+  #     several AMS public APIs (``ams.main.run``, ``Model.set``,
+  #     ``bench.harness.measure``, ``utils.tab.Tab``) are designed with
+  #     5–11 explicit kwargs for clarity; refactoring just to satisfy
+  #     the default thresholds would harm the API.
+  #   - use-list-literal / use-dict-literal: micro-style nit; fix when
+  #     touching surrounding code, don't churn on legacy modules.
+  #   - no-else-return: stylistic; explicit ``else:`` after ``return`` is
+  #     fine in short branches and improves readability.
+  #   - import-outside-toplevel: intentional in ``ams.bench.env``,
+  #     ``ams.shared``, ``ams.utils.paths``, etc. — lazy/optional-dep
+  #     imports kept at point-of-use to avoid pulling in heavy or
+  #     optional modules at package import time.
+  #   - eval-used: ``ams.utils.lazyimport`` uses ``eval()`` for
+  #     deferred-name resolution; an ``importlib`` rewrite is a
+  #     standalone follow-up (tracked in the codacy_cleanup_post_v1_2_0
+  #     plan). Suppress here in the meantime.
+  disable:
+    - too-many-arguments
+    - too-many-positional-arguments
+    - too-many-locals
+    - too-many-branches
+    - use-list-literal
+    - use-dict-literal
+    - no-else-return
+    - import-outside-toplevel
+    - eval-used

--- a/ams/bench/__main__.py
+++ b/ams/bench/__main__.py
@@ -80,7 +80,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.output == "-":
         print(payload)
     else:
-        with open(args.output, "w") as fh:
+        with open(args.output, "w", encoding="utf-8") as fh:
             fh.write(payload)
     return 0
 

--- a/ams/bench/env.py
+++ b/ams/bench/env.py
@@ -93,7 +93,7 @@ def _cpu_brand() -> str:
     proc_cpuinfo = Path("/proc/cpuinfo")
     if proc_cpuinfo.exists():
         try:
-            for line in proc_cpuinfo.read_text().splitlines():
+            for line in proc_cpuinfo.read_text(encoding='utf-8').splitlines():
                 if line.startswith("model name"):
                     return line.split(":", 1)[1].strip()
         except Exception as exc:  # env capture must never raise

--- a/ams/bench/harness.py
+++ b/ams/bench/harness.py
@@ -150,5 +150,3 @@ def summarize(
         error=error,
         **common,
     )
-
-

--- a/ams/bench/harness.py
+++ b/ams/bench/harness.py
@@ -75,7 +75,13 @@ def measure(
             fn()
     except Exception as exc:
         logger.warning("bench %s/%s: warmup failed: %s", group, name, exc)
-        return _failed(name, group, reps, warmup_reps, str(exc))
+        return summarize(
+            [],
+            name=name, group=group, reps=reps, warmup_reps=warmup_reps,
+            error=str(exc),
+            routine=routine, case=case, solver=solver, phase=phase,
+            metadata=metadata,
+        )
 
     raw: list[float] = []
     err: str | None = None
@@ -146,16 +152,3 @@ def summarize(
     )
 
 
-def _failed(name: str, group: str, reps: int, warmup_reps: int, msg: str) -> Measurement:
-    return Measurement(
-        name=name,
-        group=group,
-        reps=reps,
-        warmup_reps=warmup_reps,
-        mean_s=None,
-        stdev_s=None,
-        min_s=None,
-        max_s=None,
-        raw_s=[],
-        error=msg,
-    )

--- a/ams/core/model.py
+++ b/ams/core/model.py
@@ -242,6 +242,7 @@ class Model:
         bool
             True when successful.
         """
+        del base  # API-compat noop — accepted but ignored (see docstring)
         # Resolve attr and value from the mixed positional / keyword call styles.
         #
         # Style A (ANDES v2.0.0 GroupBase dispatch):

--- a/ams/io/__init__.py
+++ b/ams/io/__init__.py
@@ -176,6 +176,7 @@ def dump(system, output_format, full_path=None, overwrite=None, **kwargs):
                                          system.files.name + '.' + ext)
 
     t, _ = elapsed()
+    ret = False
     if output_format == 'xlsx':
         ret = xlsx.write(system, system.files.dump, overwrite=overwrite, **kwargs)
     elif output_format == 'json':

--- a/ams/system.py
+++ b/ams/system.py
@@ -627,6 +627,7 @@ class System:
         Adapted from ``andes.system.System.link_ext_param``.
         Original author: Hantao Cui. License: GPL-3.0.
         """
+        del model  # API-compat noop — AMS always links all models
         ret = True
         for mdl in self.models.values():
             for instance in mdl.params_ext.values():
@@ -759,7 +760,7 @@ class System:
                 return None
 
         conf = self.collect_config()
-        with open(file_path, 'w') as f:
+        with open(file_path, 'w', encoding='utf-8') as f:
             conf.write(f)
 
         logger.info('Config written to "%s"', file_path)
@@ -828,9 +829,9 @@ class System:
             else:
                 return name
 
-        pairs = list()
+        pairs = []
         for g in self.groups:
-            models = list()
+            models = []
             for m in self.groups[g].models:
                 models.append(rst_ref(m, export))
             if len(models) > 0:

--- a/ams/utils/lazyimport.py
+++ b/ams/utils/lazyimport.py
@@ -1,5 +1,4 @@
-"""
-Lazy import utility for optional and deferred dependencies.
+"""Lazy import utility for optional and deferred dependencies.
 
 Notes
 -----
@@ -27,6 +26,9 @@ Original pyforest license (MIT):
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 """
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class LazyImport:
@@ -60,8 +62,11 @@ class LazyImport:
         for lazy_import in self.__complementary_imports__:
             try:
                 lazy_import.__maybe_import__()
-            except Exception:  # NOQA
-                pass
+            except ImportError as exc:
+                logger.debug(
+                    "lazy complementary import %r failed: %s",
+                    lazy_import.__import_statement__, exc,
+                )
 
     def __maybe_import__(self):
         self.__maybe_import_complementary_imports__()

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -12,6 +12,17 @@ v1.2
 v1.2.2 (unreleased)
 ----------------------
 
+**Bug fixes:**
+
+- ``bench.harness.measure``: when warmup raises, the failure path now
+  preserves the structured tags (``routine``, ``case``, ``solver``,
+  ``phase``, ``metadata``) on the returned ``Measurement`` instead of
+  dropping them.
+- ``LazyImport.__maybe_import_complementary_imports__`` narrows the
+  swallowed exception from bare ``except Exception`` to
+  ``except ImportError`` and logs at DEBUG, so unexpected failures stop
+  being silently hidden.
+
 **Internal:**
 
 - Silence Codacy's Bandit findings on the env-capture subprocess calls
@@ -21,6 +32,24 @@ v1.2.2 (unreleased)
   config file when the project's pattern set is empty), so the inline
   markers are what actually apply on Codacy. Local ``bandit -c
   pyproject.toml`` runs continue to honor the skips list.
+- ``ams.io.dump``: initialize ``ret`` defensively before the
+  format-dispatch ``if/elif`` to silence pylint's
+  ``possibly-used-before-assignment``. The earlier ``output_formats``
+  membership guard already ensures one branch fires at runtime, so
+  ``ret`` was never actually unbound — this is a static-analysis
+  cleanup, not a behavior change.
+- Add ``encoding='utf-8'`` to text-mode ``open()`` /
+  ``Path.read_text`` calls in ``ams.bench.env``, ``ams.bench.__main__``,
+  and ``ams.system`` (config-file write). Avoids the platform-default
+  encoding foot-gun on Windows.
+- ``link_ext_param(model=None)`` and ``Model.set(..., base=None)``:
+  document and explicitly drop the API-compat-only arguments so they
+  no longer surface as ``unused-argument`` lint findings.
+- Bulk-disable noisy pylint patterns in ``.prospector.yaml``
+  (``too-many-arguments`` / ``-locals`` / ``-branches``,
+  ``use-list-literal`` / ``use-dict-literal``, ``no-else-return``,
+  ``import-outside-toplevel``, ``eval-used``) with rationale; replaces
+  per-PR Codacy churn on long-standing code.
 
 v1.2.1 (2026-04-29)
 ----------------------


### PR DESCRIPTION
## Summary

Companion to #239. Addresses the real-defect Codacy findings on PR #228 plus bulk-suppresses noisy pylint patterns that fire on legitimate API design (5–11 explicit kwargs, intentional lazy imports, etc.).

**Real fixes (5 touch points):**

- `ams/utils/lazyimport.py:63` — narrow `except Exception: pass` to `except ImportError:` with DEBUG log. Stops silently swallowing unexpected complementary-import failures.
- `ams/bench/harness.py` — replace the warmup-failure `_failed(...)` shortcut with `summarize([], ...)` so the returned `Measurement` preserves the structured tags (`routine`, `case`, `solver`, `phase`, `metadata`) instead of dropping them. Removes the now-redundant `_failed` helper.
- `ams/io/__init__.py` — initialize `ret = False` before the format dispatch so the trailing `if ret:` is never possibly-unbound.
- 3× `unspecified-encoding` — `ams/bench/env.py`, `ams/bench/__main__.py`, `ams/system.py:write_config` now pass `encoding='utf-8'` to text-mode reads/writes (Windows default-encoding hardening).
- `link_ext_param(model=None)` and `Model.set(..., base=None)` — explicitly `del` the API-compat-only kwargs so they no longer surface as `unused-argument`. Both have explicit \"reserved for ANDES v2.0.0 compatibility\" docstrings.
- `ams/system.py:supported_models` — `list()` → `[]` (use-list-literal one-liner).

**Bulk pylint suppressions** in `.prospector.yaml`, each with rationale:

- `too-many-arguments` / `-positional-arguments` / `-locals` / `-branches` — AMS public APIs deliberately accept 5–11 kwargs for clarity (`ams.main.run`, `Model.set`, `bench.harness.measure`, `utils.tab.Tab`). Refactoring to satisfy default thresholds would harm the API.
- `use-list-literal` / `use-dict-literal` — micro-style; fix when touching, don't churn.
- `no-else-return` — explicit `else:` after `return` is fine in short branches.
- `import-outside-toplevel` — intentional in `ams.bench.env`, `ams.shared`, etc.; lazy/optional-dep imports.
- `eval-used` — `ams.utils.lazyimport` uses `eval()` for deferred name resolution; an `importlib` rewrite is a standalone follow-up (tracked in the codacy_cleanup_post_v1_2_0 plan).

## Test plan

- [x] `pytest tests/` — 322 passed, 9 warnings (all pre-existing, unrelated)
- [x] Smoke test for harness warmup-failure: structured tags now preserved on the returned `Measurement` (verified routine/case/solver/phase/metadata all round-trip)
- [x] `import ams` clean
- [ ] Verify on Codacy after PR opens that the targeted findings are gone and no new findings surface from the bulk suppressions

## Stacking note

This branch is based on `develop`, **not** stacked on #239. There's no file overlap with PR #239 except `ams/bench/env.py` (PR #239 modifies lines 14/103/118/126; this PR modifies line 96). Once #239 merges, this branch will rebase cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)