### PR TITLE
refactor(opt): rename formulation_source 'sub_map' bucket to 'eval' (cvxpy-ns Step 5)

### DIFF
--- a/ams/opt/optzbase.py
+++ b/ams/opt/optzbase.py
@@ -196,7 +196,7 @@ class OptzBase:
           (the fast AOT path); only happens for items that exactly match
           the pristine source.
         - ``'manual'`` — author/user code assigned ``item.e_fn = fn``
-          directly, bypassing both codegen and the sub_map regex.
+          directly, bypassing both codegen and the eval-fallback helper.
         - ``'eval'`` — eval-fallback path: ``e_str`` is resolved
           symbol-by-symbol via :func:`ams.opt._runtime_eval.eval_e_str`
           and ``eval``-ed at parse/evaluate time. This is what runs for

--- a/ams/opt/optzbase.py
+++ b/ams/opt/optzbase.py
@@ -156,7 +156,7 @@ class OptzBase:
         # Provenance of the live ``e_fn`` (when one is set). Values:
         #   - 'codegen' : wired from ``~/.ams/pycode/`` by ``_link_pycode``
         #   - 'manual'  : assigned directly via ``item.e_fn = fn``
-        #   - None      : no e_fn (uses sub_map+eval path)
+        #   - None      : no e_fn (uses the eval-fallback helper)
         # Read via :pyattr:`formulation_source` — this raw attribute is
         # written by ``_link_pycode`` and reset whenever ``e_str`` is
         # reassigned (descriptor mutex side-effect).
@@ -197,10 +197,13 @@ class OptzBase:
           the pristine source.
         - ``'manual'`` — author/user code assigned ``item.e_fn = fn``
           directly, bypassing both codegen and the sub_map regex.
-        - ``'sub_map'`` — legacy path: ``e_str`` was rewritten by
-          :class:`SymProcessor` and ``eval``-ed at parse/evaluate time.
-          This is what runs for items the user customized via
-          ``e_str = '...'`` or ``addConstrs(...)``.
+        - ``'eval'`` — eval-fallback path: ``e_str`` is resolved
+          symbol-by-symbol via :func:`ams.opt._runtime_eval.eval_e_str`
+          and ``eval``-ed at parse/evaluate time. This is what runs for
+          items the user customized via ``e_str = '...'`` or
+          ``addConstrs(...)``. (Renamed from ``'sub_map'`` in v1.2.2;
+          the legacy regex+eval pipeline that name referenced was
+          retired in PR #246.)
         """
         if getattr(self, 'optz', None) is None:
             return 'pending'
@@ -212,7 +215,7 @@ class OptzBase:
             # e_fn set but provenance lost — defensive fallback. Shouldn't
             # happen in normal flow.
             return 'manual'
-        return 'sub_map'
+        return 'eval'
 
     @property
     def n(self):

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -286,7 +286,7 @@ class RoutineBase:
         # the runtime path it will take, which mirrors the per-item
         # ``formulation_source`` property.
         tally = {'codegen': 0, 'manual': 0,
-                 'sub_map_dirty': 0, 'sub_map_added': 0}
+                 'eval_dirty': 0, 'eval_added': 0}
 
         # ``_link_pycode`` is the one place that legitimately reaches
         # into ``_e_fn`` / ``_e_dirty`` / ``_e_fn_source`` on opt items —
@@ -299,17 +299,17 @@ class RoutineBase:
             if getattr(item, '_e_dirty', False):
                 # User modified this item; we leave it alone. The runtime
                 # path is 'manual' if a callable is now in place,
-                # otherwise the legacy 'sub_map' regex pipeline.
+                # otherwise the eval-fallback helper.
                 if getattr(item, '_e_fn', None) is not None:
                     tally['manual'] += 1
                 else:
-                    tally['sub_map_dirty'] += 1
+                    tally['eval_dirty'] += 1
                 return
             pristine_str = _pristine_e_str(prefix, name)
             if (pristine_str is not None
                     and getattr(item, '_e_str', None) != pristine_str):
                 item._e_dirty = True
-                tally['sub_map_dirty'] += 1
+                tally['eval_dirty'] += 1
                 return
             fn = getattr(gen, f'_{prefix}_{name}', None)
             if fn is not None:
@@ -323,9 +323,9 @@ class RoutineBase:
                 tally['codegen'] += 1
             else:
                 # Item has no entry in pycode (e.g. added at runtime via
-                # ``addConstrs``). It will fall through to the sub_map
-                # path at parse/evaluate time.
-                tally['sub_map_added'] += 1
+                # ``addConstrs``). It will fall through to the eval-fallback
+                # helper (ams.opt._runtime_eval) at parse/evaluate time.
+                tally['eval_added'] += 1
             tex = getattr(gen, f'_{prefix}_{name}_tex', None)
             if tex is not None and getattr(item, 'e_tex', None) is None:
                 item.e_tex = tex
@@ -350,10 +350,10 @@ class RoutineBase:
             parts = [f"codegen={tally['codegen']}/{total}"]
             if tally['manual']:
                 parts.append(f"manual={tally['manual']}")
-            if tally['sub_map_dirty']:
-                parts.append(f"sub_map(customized)={tally['sub_map_dirty']}")
-            if tally['sub_map_added']:
-                parts.append(f"sub_map(added)={tally['sub_map_added']}")
+            if tally['eval_dirty']:
+                parts.append(f"eval(customized)={tally['eval_dirty']}")
+            if tally['eval_added']:
+                parts.append(f"eval(added)={tally['eval_added']}")
             logger.info(
                 "<%s> formulation: %s", self.class_name, ", ".join(parts)
             )
@@ -364,7 +364,7 @@ class RoutineBase:
 
         Useful for verifying which path each opt element runs through after
         custom edits — e.g. ``addConstrs`` and ``obj.e_str += '...'``
-        should show ``sub_map``, while untouched items show ``codegen``.
+        should show ``eval``, while untouched items show ``codegen``.
 
         Parameters
         ----------
@@ -401,7 +401,7 @@ class RoutineBase:
         sw = max(len(r[2]) for r in rows)
         print(f"<{self.class_name}> formulation summary "
               f"({sum(1 for r in rows if r[2] == 'codegen')} codegen / "
-              f"{sum(1 for r in rows if r[2] == 'sub_map')} sub_map / "
+              f"{sum(1 for r in rows if r[2] == 'eval')} eval / "
               f"{sum(1 for r in rows if r[2] == 'manual')} manual / "
               f"{sum(1 for r in rows if r[2] == 'pending')} pending)")
         print(f"  {'kind':<{kw}}  {'name':<{nw}}  {'source':<{sw}}  e_str")

--- a/docs/source/modeling/routine.rst
+++ b/docs/source/modeling/routine.rst
@@ -161,7 +161,11 @@ every routine init. The first time a routine is instantiated, AMS:
 
 1. Walks the constructed routine's ``constrs`` / ``exprs`` / ``exprcs``
    / ``obj`` registries.
-2. Applies the ``sub_map`` rewrites to each ``e_str``.
+2. Resolves bare symbol names in each ``e_str`` (``pg`` →
+   ``r.pg``, …) via the same ``_build_symbol_regex`` /
+   ``_collect_symbol_names`` pass used by the eval-fallback helper.
+   Function names (``cp.sum``, ``cp.multiply``, …) are passed
+   through untouched.
 3. Emits a small Python module at ``~/.ams/pycode/<routine>.py`` with
    one named callable per opt element — e.g.
    ``def _constr_pglb(r): return -r.pg + r.pmine`` — plus the

--- a/docs/source/modeling/routine.rst
+++ b/docs/source/modeling/routine.rst
@@ -183,8 +183,8 @@ Authors who prefer to skip the DSL and write a callable directly may
 pass ``e_fn=callable`` instead of ``e_str``; the runtime accepts both,
 and the codegen leaves manually-set ``e_fn`` alone.
 
-Two execution paths: codegen vs ``sub_map``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Two execution paths: codegen vs ``eval``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Internally, two execution paths from ``e_str`` to a CVXPY object live
 side by side:
@@ -196,18 +196,16 @@ side by side:
   just invoke the callable with a :py:class:`ams.core.routine_ns.RoutineNS`
   proxy; no regex, no ``eval``.
 
-- **``sub_map`` path** (legacy, used as a fall-through). At ``parse()``
-  time, :py:class:`ams.core.symprocessor.SymProcessor` regex-rewrites
-  the item's ``e_str`` to resolve bare symbol names (``pg`` →
-  ``self.om.pg``, ``Cft`` → ``self.om.Cft``, …) and stores it in
-  ``item.code``. ``evaluate()`` then ``eval``\ s ``item.code``.
-  Function names (``cp.sum``, ``cp.multiply``, …) are not rewritten
-  — author canonical CVXPY in ``e_str`` and the sub_map path passes
-  them through.
+- **Eval-fallback path** (used for items the codegen doesn't cover).
+  At ``parse()`` time, :py:func:`ams.opt._runtime_eval.eval_e_str`
+  resolves bare symbol names (``pg`` → ``r.pg``, ``Cft`` → ``r.Cft``,
+  …) via a single regex pass and ``eval``\ s the result against a
+  ``RoutineNS`` proxy. Function names (``cp.sum``, ``cp.multiply``,
+  …) are not rewritten — author canonical CVXPY in ``e_str`` and the
+  helper passes them through.
 
 Both paths must produce the same CVXPY object given the same ``e_str``
-— the codegen is the AOT-compiled version of the ``sub_map`` rewrite
-pipeline.
+— the codegen is the AOT-compiled version of the eval-fallback pipeline.
 
 Which path runs is decided per-item by ``_link_pycode``:
 
@@ -224,13 +222,13 @@ Which path runs is decided per-item by ``_link_pycode``:
        from; ``e_fn`` is wired from the cache.
    * - Added at runtime via ``addConstrs`` / ``addExpressions`` /
        ``addExprcs``
-     - sub_map
+     - eval
      - The cache (always generated against a pristine instance —
        see :ref:`pycode-pristine-invariant` below) doesn't know
        about runtime additions.
    * - ``e_str`` reassigned post-construction (e.g.
        ``obj.e_str += '+ ...'``)
-     - sub_map
+     - eval
      - The descriptor mutex on ``e_str`` / ``e_fn`` marks the item
        ``_e_dirty``; ``_link_pycode`` skips wiring so the user's new
        ``e_str`` flows through ``parse()``.
@@ -238,7 +236,7 @@ Which path runs is decided per-item by ``_link_pycode``:
 Authors and users can introspect which path is in effect:
 
 - :py:attr:`ams.opt.OptzBase.formulation_source` — per-item, returns
-  ``'codegen' | 'sub_map' | 'manual' | 'pending'``.
+  ``'codegen' | 'eval' | 'manual' | 'pending'``.
 - :py:meth:`ams.routines.routine.RoutineBase.formulation_summary` —
   full table.
 - An INFO-level log line ``<RoutineName> formulation: codegen=X/Y, …``

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -66,6 +66,17 @@ should switch to ``formulation_source`` plus the routine's
 ``vars`` / ``rparams`` / ``services`` / ``exprs`` / ``constrs``
 registries.
 
+The :py:attr:`ams.opt.OptzBase.formulation_source` value
+``'sub_map'`` is renamed to ``'eval'``. The string referred to
+the (now-deleted) ``SymProcessor.sub_map`` regex pipeline; the
+new name reflects the live implementation —
+``ams.opt._runtime_eval.eval_e_str`` /
+``eval_e_str_numeric``. Code that compared
+``item.formulation_source == 'sub_map'`` must update to
+``'eval'``. The corresponding INFO log keys (formerly
+``sub_map(customized)`` / ``sub_map(added)``) and
+``formulation_summary`` print bucket are renamed in lockstep.
+
 **New features:**
 
 - **Opt-layer codegen.** Routine constraints, expressions, and
@@ -106,12 +117,12 @@ registries.
   execution path an opt element runs through after ``init()``:
 
   - per-item :py:attr:`ams.opt.OptzBase.formulation_source` →
-    ``'codegen' | 'sub_map' | 'manual' | 'pending'``;
+    ``'codegen' | 'eval' | 'manual' | 'pending'``;
   - :py:meth:`ams.routines.routine.RoutineBase.formulation_summary`
     prints a per-item table;
   - an INFO log line on every ``init()``::
 
-       <DCOPF> formulation: codegen=14/17, sub_map(customized)=1, sub_map(added)=2
+       <DCOPF> formulation: codegen=14/17, eval(customized)=1, eval(added)=2
 
   Useful for confirming a runtime customization
   (``addConstrs``, ``obj.e_str += '...'``) actually reaches the

--- a/examples/ex8.ipynb
+++ b/examples/ex8.ipynb
@@ -20,8 +20,8 @@
     "   pycode at `~/.ams/pycode/dcopf.py`.\n",
     "2. **You can see which path each item runs through.** The\n",
     "   `routine.formulation_summary()` API tells you exactly what's in\n",
-    "   effect — `codegen` (fast AOT path) or `sub_map` (legacy regex+eval,\n",
-    "   used for runtime customizations).\n"
+    "   effect — `codegen` (fast AOT path) or `eval` (the eval-fallback\n",
+    "   helper, used for runtime customizations)."
    ]
   },
   {
@@ -37,9 +37,10 @@
     "into named callables that live in `~/.ams/pycode/<routine>.py`. The\n",
     "runtime then either wires those callables onto items (the\n",
     "`codegen` path) or, for items the user customized at runtime,\n",
-    "falls back to the legacy regex+eval pipeline driven by\n",
-    "`SymProcessor.sub_map` (the `sub_map` path). Both paths produce\n",
-    "the same CVXPY object given the same `e_str`."
+    "falls back to a single eval-fallback helper\n",
+    "(`ams.opt._runtime_eval.eval_e_str`) that resolves bare symbol\n",
+    "names through `RoutineNS`. Both paths produce the same CVXPY\n",
+    "object given the same `e_str`."
    ]
   },
   {
@@ -48,10 +49,10 @@
    "id": "36eb23ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:28.164888Z",
-     "iopub.status.busy": "2026-04-30T10:03:28.164339Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.318806Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.318507Z"
+     "iopub.execute_input": "2026-05-02T06:30:12.724122Z",
+     "iopub.status.busy": "2026-05-02T06:30:12.723210Z",
+     "iopub.status.idle": "2026-05-02T06:30:13.838070Z",
+     "shell.execute_reply": "2026-05-02T06:30:13.837744Z"
     }
    },
    "outputs": [],
@@ -76,10 +77,10 @@
    "id": "a803c68e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.320297Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.320172Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.577191Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.576949Z"
+     "iopub.execute_input": "2026-05-02T06:30:13.839727Z",
+     "iopub.status.busy": "2026-05-02T06:30:13.839579Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.096480Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.096219Z"
     }
    },
    "outputs": [
@@ -101,7 +102,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Input file parsed in 0.1040 seconds.\n"
+      "Input file parsed in 0.0992 seconds.\n"
      ]
     },
     {
@@ -122,7 +123,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "System set up in 0.0019 seconds.\n"
+      "System set up in 0.0021 seconds.\n"
      ]
     },
     {
@@ -178,14 +179,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> initialized in 0.0433 seconds.\n"
+      "<DCOPF> initialized in 0.0429 seconds.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> solved as optimal in 0.0066 seconds, converged in 9 iterations with CLARABEL.\n"
+      "<DCOPF> solved as optimal in 0.0069 seconds, converged in 9 iterations with CLARABEL.\n"
      ]
     },
     {
@@ -211,10 +212,10 @@
    "id": "a7853b7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.578308Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.578231Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.580006Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.579818Z"
+     "iopub.execute_input": "2026-05-02T06:30:14.097858Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.097746Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.099554Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.099323Z"
     }
    },
    "outputs": [
@@ -238,10 +239,10 @@
    "id": "52ee8895",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.581048Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.580949Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.582660Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.582423Z"
+     "iopub.execute_input": "2026-05-02T06:30:14.100642Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.100574Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.102291Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.102040Z"
     }
    },
    "outputs": [
@@ -249,24 +250,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<DCOPF> formulation summary (15 codegen / 0 sub_map / 0 manual / 0 pending)\n",
+      "<DCOPF> formulation summary (15 codegen / 0 eval / 0 manual / 0 pending)\n",
       "  kind      name   source   e_str\n",
       "  --------  -----  -------  ----------------------------------------\n",
       "  expr      plf    codegen  Bf@aBus + Pfinj\n",
-      "  expr      pmaxe  codegen  mul(nctrle, pg0) + mul(ctrle, pmax)\n",
-      "  expr      pmine  codegen  mul(nctrle, pg0) + mul(ctrle, pmin)\n",
+      "  expr      pmaxe  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmax)\n",
+      "  expr      pmine  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmin)\n",
       "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg\n",
       "  constr    sba    codegen  isb@aBus\n",
       "  constr    pglb   codegen  -pg + pmine\n",
       "  constr    pgub   codegen  pg - pmaxe\n",
-      "  constr    plflb  codegen  -plf - mul(ul, rate_a)\n",
-      "  constr    plfub  codegen  plf - mul(ul, rate_a)\n",
+      "  constr    plflb  codegen  -plf - cp.multiply(ul, rate_a)\n",
+      "  constr    plfub  codegen  plf - cp.multiply(ul, rate_a)\n",
       "  constr    alflb  codegen  -CftT@aBus + amin\n",
       "  constr    alfub  codegen  CftT@aBus - amax\n",
       "  exprcalc  pi     codegen  pb.dual_variables[0]\n",
       "  exprcalc  mu1    codegen  plflb.dual_variables[0]\n",
       "  exprcalc  mu2    codegen  plfub.dual_variables[0]\n",
-      "  obj       obj    codegen  sum(mul(c2, pg**2))+ sum(mul(c1, pg))+ sum(mul(ug, c0))\n"
+      "  obj       obj    codegen  cp.sum(cp.multiply(c2, pg**2))+ cp.sum(cp.multiply(c1, pg))+\n"
      ]
     }
    ],
@@ -299,127 +300,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "b4f49c0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.583986Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.583911Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.716875Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.716659Z"
-    }
-   },
-   "outputs": [],
-   "source": "sp2 = ams.load(ams.get_case('5bus/pjm5bus_demo.xlsx'),\n                setup=True, no_output=True, default_config=True)\nsp2.DCOPF.init()  # populate om so .get(...) works\n\nstg_idx = sp2.DCOPF.pg.get_all_idxes()\npmax = sp2.DCOPF.get(src='pmax', attr='v', idx=stg_idx)\n\n# Heterogeneous emission factor — proportional to 1/pmax (a stand-in\n# for: small/peaker units are less efficient and emit more per p.u.).\nke = np.reciprocal(pmax)\n# Per-unit tax — also 1/pmax.\nce = np.reciprocal(pmax)\n\nsp2.DCOPF.addRParam(name='ke', tex_name='k_e', info='emission factor', v=ke)\nsp2.DCOPF.addRParam(name='ce', tex_name='c_e', info='per-unit tax', v=ce)\n# Cap chosen so the eub constraint actually binds. The baseline solution has\n# sum(ke @ pg) ~ 1.53 — picking te = 1.0 forces ~35% redistribution.\nsp2.DCOPF.addService(name='te', tex_name='t_e', info='emission cap', value=1.0)\nsp2.DCOPF.addVars(name='eg', tex_name='e_g', info='gen emission',\n                   unit='t', model='StaticGen')\nsp2.DCOPF.addConstrs(name='egb', info='emission balance',\n                      e_str='eg - cp.multiply(ke, pg)', is_eq=True)\nsp2.DCOPF.addConstrs(name='eub', info='emission cap',\n                      e_str='cp.sum(eg) - te', is_eq=False)\nsp2.DCOPF.obj.e_str += '+ cp.sum(cp.multiply(ce, pg))'\n\nsp2.DCOPF.run(solver='CLARABEL')"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "90ef5387",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.718027Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.717902Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.719797Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.719574Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pg  = [0.2        2.11651035 0.6        6.41765794 0.66583171]\n",
-      "obj = 11.297128566649729\n"
-     ]
-    }
-   ],
-   "source": [
-    "print('pg  =', sp2.DCOPF.pg.v)\n",
-    "print('obj =', float(sp2.DCOPF.obj.v))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "2665d6ff",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.720731Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.720655Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.722346Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.722120Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<DCOPF> formulation summary (14 codegen / 3 sub_map / 0 manual / 0 pending)\n",
-      "  kind      name   source   e_str\n",
-      "  --------  -----  -------  ----------------------------------------\n",
-      "  expr      plf    codegen  Bf@aBus + Pfinj\n",
-      "  expr      pmaxe  codegen  mul(nctrle, pg0) + mul(ctrle, pmax)\n",
-      "  expr      pmine  codegen  mul(nctrle, pg0) + mul(ctrle, pmin)\n",
-      "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg\n",
-      "  constr    sba    codegen  isb@aBus\n",
-      "  constr    pglb   codegen  -pg + pmine\n",
-      "  constr    pgub   codegen  pg - pmaxe\n",
-      "  constr    plflb  codegen  -plf - mul(ul, rate_a)\n",
-      "  constr    plfub  codegen  plf - mul(ul, rate_a)\n",
-      "  constr    alflb  codegen  -CftT@aBus + amin\n",
-      "  constr    alfub  codegen  CftT@aBus - amax\n",
-      "  constr    egb    sub_map  eg - mul(ke, pg)\n",
-      "  constr    eub    sub_map  sum(eg) - te\n",
-      "  exprcalc  pi     codegen  pb.dual_variables[0]\n",
-      "  exprcalc  mu1    codegen  plflb.dual_variables[0]\n",
-      "  exprcalc  mu2    codegen  plfub.dual_variables[0]\n",
-      "  obj       obj    sub_map  sum(mul(c2, pg**2))+ sum(mul(c1, pg))+ sum(mul(ug, c0))+ sum\n"
-     ]
-    }
-   ],
-   "source": [
-    "sp2.DCOPF.formulation_summary()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ecfead40",
-   "metadata": {},
-   "source": [
-    "Three items are now `sub_map` (the legacy regex+eval pipeline):\n",
-    "\n",
-    "- `egb` and `eub` were added at runtime via `addConstrs` — the disk\n",
-    "  pycode doesn't know about them, so they fall through.\n",
-    "- `obj` was customized via `obj.e_str += '...'`. The descriptor mutex\n",
-    "  marked it `_e_dirty`, so `_link_pycode` skipped wiring its codegen\n",
-    "  callable.\n",
-    "\n",
-    "Everything else stays on `codegen`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d99135af",
-   "metadata": {},
-   "source": [
-    "## sp3 — DCOPF, untouched, solve\n",
-    "\n",
-    "This is the contamination check: did `sp2`'s customization leak into the\n",
-    "disk cache? If it did, `sp3` would inherit `sp2`'s formulation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "080b56ac",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.723504Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.723414Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.803567Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.803373Z"
+     "iopub.execute_input": "2026-05-02T06:30:14.103557Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.103483Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.242394Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.242163Z"
     }
    },
    "outputs": [
@@ -441,7 +329,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Input file parsed in 0.0308 seconds.\n"
+      "Input file parsed in 0.0791 seconds.\n"
      ]
     },
     {
@@ -462,7 +350,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "System set up in 0.0016 seconds.\n"
+      "System set up in 0.0020 seconds.\n"
      ]
     },
     {
@@ -518,14 +406,320 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> initialized in 0.0048 seconds.\n"
+      "<DCOPF> initialized in 0.0055 seconds.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> solved as optimal in 0.0048 seconds, converged in 9 iterations with CLARABEL.\n"
+      "Entering data check for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " -> Data check passed\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> formulation: codegen=14/17, eval(customized)=1, eval(added)=2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsing OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Finalizing OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> initialized in 0.0054 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> solved as optimal in 0.0059 seconds, converged in 12 iterations with CLARABEL.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sp2 = ams.load(ams.get_case('5bus/pjm5bus_demo.xlsx'),\n",
+    "                setup=True, no_output=True, default_config=True)\n",
+    "sp2.DCOPF.init()  # populate om so .get(...) works\n",
+    "\n",
+    "stg_idx = sp2.DCOPF.pg.get_all_idxes()\n",
+    "pmax = sp2.DCOPF.get(src='pmax', attr='v', idx=stg_idx)\n",
+    "\n",
+    "# Heterogeneous emission factor — proportional to 1/pmax (a stand-in\n",
+    "# for: small/peaker units are less efficient and emit more per p.u.).\n",
+    "ke = np.reciprocal(pmax)\n",
+    "# Per-unit tax — also 1/pmax.\n",
+    "ce = np.reciprocal(pmax)\n",
+    "\n",
+    "sp2.DCOPF.addRParam(name='ke', tex_name='k_e', info='emission factor', v=ke)\n",
+    "sp2.DCOPF.addRParam(name='ce', tex_name='c_e', info='per-unit tax', v=ce)\n",
+    "# Cap chosen so the eub constraint actually binds. The baseline solution has\n",
+    "# sum(ke @ pg) ~ 1.53 — picking te = 1.0 forces ~35% redistribution.\n",
+    "sp2.DCOPF.addService(name='te', tex_name='t_e', info='emission cap', value=1.0)\n",
+    "sp2.DCOPF.addVars(name='eg', tex_name='e_g', info='gen emission',\n",
+    "                   unit='t', model='StaticGen')\n",
+    "sp2.DCOPF.addConstrs(name='egb', info='emission balance',\n",
+    "                      e_str='eg - cp.multiply(ke, pg)', is_eq=True)\n",
+    "sp2.DCOPF.addConstrs(name='eub', info='emission cap',\n",
+    "                      e_str='cp.sum(eg) - te', is_eq=False)\n",
+    "sp2.DCOPF.obj.e_str += '+ cp.sum(cp.multiply(ce, pg))'\n",
+    "\n",
+    "sp2.DCOPF.run(solver='CLARABEL')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "90ef5387",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T06:30:14.243771Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.243662Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.245569Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.245353Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pg  = [0.2        2.11651035 0.6        6.41765794 0.66583171]\n",
+      "obj = 11.297128566649729\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('pg  =', sp2.DCOPF.pg.v)\n",
+    "print('obj =', float(sp2.DCOPF.obj.v))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2665d6ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T06:30:14.246813Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.246711Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.248468Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.248259Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> formulation summary (14 codegen / 3 eval / 0 manual / 0 pending)\n",
+      "  kind      name   source   e_str\n",
+      "  --------  -----  -------  ----------------------------------------\n",
+      "  expr      plf    codegen  Bf@aBus + Pfinj\n",
+      "  expr      pmaxe  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmax)\n",
+      "  expr      pmine  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmin)\n",
+      "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg\n",
+      "  constr    sba    codegen  isb@aBus\n",
+      "  constr    pglb   codegen  -pg + pmine\n",
+      "  constr    pgub   codegen  pg - pmaxe\n",
+      "  constr    plflb  codegen  -plf - cp.multiply(ul, rate_a)\n",
+      "  constr    plfub  codegen  plf - cp.multiply(ul, rate_a)\n",
+      "  constr    alflb  codegen  -CftT@aBus + amin\n",
+      "  constr    alfub  codegen  CftT@aBus - amax\n",
+      "  constr    egb    eval     eg - cp.multiply(ke, pg)\n",
+      "  constr    eub    eval     cp.sum(eg) - te\n",
+      "  exprcalc  pi     codegen  pb.dual_variables[0]\n",
+      "  exprcalc  mu1    codegen  plflb.dual_variables[0]\n",
+      "  exprcalc  mu2    codegen  plfub.dual_variables[0]\n",
+      "  obj       obj    eval     cp.sum(cp.multiply(c2, pg**2))+ cp.sum(cp.multiply(c1, pg))+\n"
+     ]
+    }
+   ],
+   "source": [
+    "sp2.DCOPF.formulation_summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecfead40",
+   "metadata": {},
+   "source": [
+    "Three items are now `eval` (the eval-fallback helper):\n",
+    "\n",
+    "- `egb` and `eub` were added at runtime via `addConstrs` — the disk\n",
+    "  pycode doesn't know about them, so they fall through.\n",
+    "- `obj` was customized via `obj.e_str += '...'`. The descriptor mutex\n",
+    "  marked it `_e_dirty`, so `_link_pycode` skipped wiring its codegen\n",
+    "  callable.\n",
+    "\n",
+    "Everything else stays on `codegen`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d99135af",
+   "metadata": {},
+   "source": [
+    "## sp3 — DCOPF, untouched, solve\n",
+    "\n",
+    "This is the contamination check: did `sp2`'s customization leak into the\n",
+    "disk cache? If it did, `sp3` would inherit `sp2`'s formulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "080b56ac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T06:30:14.249525Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.249457Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.331101Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.330893Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Working directory: \"/Users/jinningwang/work/ams/examples\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsing input file \"/Users/jinningwang/work/ams/ams/cases/5bus/pjm5bus_demo.xlsx\"...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Input file parsed in 0.0318 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Zero Line parameters detected, adjusted to default values: rate_b, rate_c.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "All bus type are PQ, adjusted given load and generator connection status.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "System set up in 0.0018 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Entering data check for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " -> Data check passed\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Building system matrices\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> formulation: codegen=15/15\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsing OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Finalizing OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> initialized in 0.0053 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> solved as optimal in 0.0049 seconds, converged in 9 iterations with CLARABEL.\n"
      ]
     },
     {
@@ -551,10 +745,10 @@
    "id": "0ff00f4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.804650Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.804576Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.806337Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.806158Z"
+     "iopub.execute_input": "2026-05-02T06:30:14.332189Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.332114Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.333920Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.333742Z"
     }
    },
    "outputs": [
@@ -578,10 +772,10 @@
    "id": "200d1fd0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.807284Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.807209Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.809043Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.808761Z"
+     "iopub.execute_input": "2026-05-02T06:30:14.334808Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.334739Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.336459Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.336235Z"
     }
    },
    "outputs": [
@@ -589,24 +783,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<DCOPF> formulation summary (15 codegen / 0 sub_map / 0 manual / 0 pending)\n",
+      "<DCOPF> formulation summary (15 codegen / 0 eval / 0 manual / 0 pending)\n",
       "  kind      name   source   e_str\n",
       "  --------  -----  -------  ----------------------------------------\n",
       "  expr      plf    codegen  Bf@aBus + Pfinj\n",
-      "  expr      pmaxe  codegen  mul(nctrle, pg0) + mul(ctrle, pmax)\n",
-      "  expr      pmine  codegen  mul(nctrle, pg0) + mul(ctrle, pmin)\n",
+      "  expr      pmaxe  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmax)\n",
+      "  expr      pmine  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmin)\n",
       "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg\n",
       "  constr    sba    codegen  isb@aBus\n",
       "  constr    pglb   codegen  -pg + pmine\n",
       "  constr    pgub   codegen  pg - pmaxe\n",
-      "  constr    plflb  codegen  -plf - mul(ul, rate_a)\n",
-      "  constr    plfub  codegen  plf - mul(ul, rate_a)\n",
+      "  constr    plflb  codegen  -plf - cp.multiply(ul, rate_a)\n",
+      "  constr    plfub  codegen  plf - cp.multiply(ul, rate_a)\n",
       "  constr    alflb  codegen  -CftT@aBus + amin\n",
       "  constr    alfub  codegen  CftT@aBus - amax\n",
       "  exprcalc  pi     codegen  pb.dual_variables[0]\n",
       "  exprcalc  mu1    codegen  plflb.dual_variables[0]\n",
       "  exprcalc  mu2    codegen  plfub.dual_variables[0]\n",
-      "  obj       obj    codegen  sum(mul(c2, pg**2))+ sum(mul(c1, pg))+ sum(mul(ug, c0))\n"
+      "  obj       obj    codegen  cp.sum(cp.multiply(c2, pg**2))+ cp.sum(cp.multiply(c1, pg))+\n"
      ]
     }
    ],
@@ -628,10 +822,10 @@
    "id": "e56c6dfb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.810324Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.810239Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.812474Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.812278Z"
+     "iopub.execute_input": "2026-05-02T06:30:14.337479Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.337415Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.339635Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.339416Z"
     }
    },
    "outputs": [
@@ -666,8 +860,8 @@
     "\n",
     "- `routine.formulation_summary()` — full per-item table.\n",
     "- `item.formulation_source` — single-item check, returns one of\n",
-    "  `'codegen' | 'sub_map' | 'manual' | 'pending'`.\n",
-    "- The INFO log line `<{routine}> formulation: codegen=X/Y, sub_map(...)=Z`\n",
+    "  `'codegen' | 'eval' | 'manual' | 'pending'`.\n",
+    "- The INFO log line `<{routine}> formulation: codegen=X/Y, eval(...)=Z`\n",
     "  prints on every `init()`.\n",
     "\n",
     "If you customized something but its source still reads `codegen`, the\n",
@@ -680,17 +874,17 @@
    "id": "c768505d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.813771Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.813689Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.815740Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.815490Z"
+     "iopub.execute_input": "2026-05-02T06:30:14.340712Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.340637Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.342509Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.342324Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'sub_map'"
+       "'eval'"
       ]
      },
      "execution_count": 12,
@@ -708,17 +902,17 @@
    "id": "d329d0f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.816748Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.816674Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.818501Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.818300Z"
+     "iopub.execute_input": "2026-05-02T06:30:14.343448Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.343379Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.345155Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.344959Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'sub_map'"
+       "'eval'"
       ]
      },
      "execution_count": 13,
@@ -736,10 +930,10 @@
    "id": "4ed99879",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-30T10:03:29.819371Z",
-     "iopub.status.busy": "2026-04-30T10:03:29.819305Z",
-     "iopub.status.idle": "2026-04-30T10:03:29.820981Z",
-     "shell.execute_reply": "2026-04-30T10:03:29.820769Z"
+     "iopub.execute_input": "2026-05-02T06:30:14.346203Z",
+     "iopub.status.busy": "2026-05-02T06:30:14.346115Z",
+     "iopub.status.idle": "2026-05-02T06:30:14.347864Z",
+     "shell.execute_reply": "2026-05-02T06:30:14.347690Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary

Final mechanical step of the cvxpy-namespace passthrough project. The `formulation_source` label `'sub_map'` referenced the (now-deleted) `SymProcessor.sub_map` regex pipeline; the live implementation is the eval-fallback helper at `ams.opt._runtime_eval.eval_e_str`. Renames everything in lockstep so the introspection vocabulary matches the runtime.

- `OptzBase.formulation_source` returns `'eval'` (was `'sub_map'`).
- `_link_pycode` tally keys: `sub_map_dirty` → `eval_dirty`, `sub_map_added` → `eval_added`.
- Per-init INFO log labels: `sub_map(customized)=N` / `sub_map(added)=N` → `eval(customized)=N` / `eval(added)=N`.
- `formulation_summary` header bucket: `… sub_map …` → `… eval …`.
- Sphinx docs (`modeling/routine.rst`), release-notes (v1.2.2), and the `ex8.ipynb` walkthrough updated; `ex8` outputs re-executed.
- The previously-deferred `optzbase.py:159` provenance comment from PR #246's review is fixed here as part of the same rename.

No production-code reader compares against the string `'sub_map'` (audit found zero asserts in `tests/`). Anyone *introspecting* `formulation_source` from outside the repo must update string comparisons — documented under v1.2.2's "Migration" section in release-notes.

## Diff stats

```
 ams/opt/optzbase.py              |  15 +-
 ams/routines/routine.py          |  26 +--
 docs/source/modeling/routine.rst |  28 ++-
 docs/source/release-notes.rst    |  15 +-
 examples/ex8.ipynb               | 390 +++++++++++++++++++++++++++++----------
 5 files changed, 340 insertions(+), 134 deletions(-)
```

(The notebook is large because re-executing `ex8.ipynb` rewrites every output block + execution timestamp; substantive content changes are limited to the `'sub_map'` → `'eval'` substitutions in markdown and captured outputs.)

## Test plan

- [x] `pytest tests/` — 348 passed locally on macOS / Python 3.12 / CLARABEL.
- [x] `flake8 ams/ --max-line-length=120 --exclude=ams/thirdparty` — clean.
- [x] DCOPF: `formulation_source == 'eval'` on the eval-fallback path after `obj.e_str += ' + 0'` + reparse; `formulation_summary` prints `(14 codegen / 1 eval / 0 manual / 0 pending)`.
- [x] `ex8.ipynb` re-executed end-to-end; all outputs now show `eval` and the customization demo (`egb` / `eub` / `obj`) lands in the `eval` bucket.
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)