### PR TITLE
refactor(opt): retire Constraint.is_eq — embedded-operator LHS-zero e_str

### DIFF
--- a/ams/core/documenter.py
+++ b/ams/core/documenter.py
@@ -352,15 +352,15 @@ class RDocumenter:
             class_names.append(p.class_name)
             info.append(p.info if p.info else '')
 
-        # expressions based on output format
+        # expressions based on output format. The relational operator
+        # is now part of ``e_str`` itself (post `is_eq` retirement);
+        # ``_tex_pre`` translates ``<= 0`` / ``== 0`` / ``>= 0`` to
+        # the LaTeX form via the trio of rules at the tail of
+        # ``_TEX_TEMPLATES`` (and the parallel ``SymProcessor.tex_map``).
         expressions = []
         if export == 'rest':
             for p in self.parent.constrs.values():
                 expr = _tex_pre(self, p, self.parent.syms.tex_map)
-                if p.is_eq:
-                    expr = f'{expr} = 0'
-                else:
-                    expr = f'{expr} \\leq 0'
                 logger.debug(f'{p.name} math: {expr}')
                 expressions.append(expr)
 

--- a/ams/core/symprocessor.py
+++ b/ams/core/symprocessor.py
@@ -74,6 +74,15 @@ class SymProcessor:
             (r'\bsum\b', 'SUM'),
             (r'power\((.*?),\s*(\d+)\)', r'\1^\2'),
             (r'(\w+).dual_variables\[0\]', r'\phi[\1]'),
+            # Relational operators in embedded-operator e_str (post
+            # `is_eq` retirement). Ordering within this trio doesn't
+            # matter (no overlap among `<=`, `>=`, `==`). Double
+            # backslash in the replacement so `re.sub` emits a
+            # literal `\leq` / `\geq` (Python 3.12+ raises
+            # re.PatternError on the single-backslash form).
+            (r'<=', r'\\leq'),
+            (r'>=', r'\\geq'),
+            (r'==', '='),
         ])
 
         self.status = {

--- a/ams/opt/_runtime_eval.py
+++ b/ams/opt/_runtime_eval.py
@@ -20,6 +20,7 @@ function-rewrite layer was deleted in PR #244):
 """
 
 import logging
+import re
 
 import cvxpy as cp
 import numpy as np
@@ -102,6 +103,9 @@ def eval_e_str(item, e_str):
         ) from exc
 
 
+_TRAILING_OP_RE = re.compile(r'\s*(==|<=|>=)\s*0\s*$')
+
+
 def eval_e_str_numeric(item, e_str):
     """Evaluate ``e_str`` numerically for :pyattr:`OptzBase.e`.
 
@@ -114,12 +118,16 @@ def eval_e_str_numeric(item, e_str):
     ``val_map`` + ``np.<atom>`` rewrite produced, but driven by the
     same name-resolution surface as the CVXPY-side helper.
 
-    For a ``cp.constraints.Constraint`` result (e.g. an ``e_str``
-    that already contains ``<= 0``), returns the constraint's LHS
-    expression so callers can ``.value`` it uniformly.
+    For an ``e_str`` carrying an embedded relational operator
+    (``... <= 0`` / ``... == 0`` / ``... >= 0``), strip the trailing
+    operator before evaluating so the returned object is the LHS
+    slack — what ``Constraint.v`` reports via CVXPY canonicalization
+    on the symbolic side. Without the strip, a numpy-only eval
+    short-circuits to a bool array.
     """
     rtn = item.om.rtn
-    code = _resolve(rtn, e_str)
+    body = _TRAILING_OP_RE.sub('', e_str)
+    code = _resolve(rtn, body)
     local_vars = {
         'cp': cp, 'np': np, 'sps': sps,
         'r': NumericRoutineNS(rtn), 'self': item,

--- a/ams/opt/constraint.py
+++ b/ams/opt/constraint.py
@@ -134,11 +134,16 @@ class Constraint(OptzBase):
             logger.debug(pretty_long_message(msg, _prefix, max_length=_max_length))
             result = eval_e_str(self, self.e_str)
         if not isinstance(result, cp.constraints.Constraint):
+            source = f"e_str={self.e_str!r}" if self.e_str is not None else "e_fn"
             raise TypeError(
-                f"Constraint <{self.name}> e_str/e_fn must produce a "
+                f"Constraint <{self.name}>: {source} must produce a "
                 f"cp.constraints.Constraint (embed the relational "
                 f"operator: '<LHS> <= 0', '<LHS> == 0', or '<LHS> >= 0'). "
-                f"Got {type(result).__name__}."
+                f"Got {type(result).__name__}. Stale "
+                f"~/.ams/pycode/ from before the v1.2.2 is_eq retirement "
+                f"is auto-invalidated by PYCODE_FORMAT_VERSION; if you see "
+                f"this from a freshly-regenerated cache, the underlying "
+                f"e_str is missing its trailing operator."
             )
         self.optz = result
         return True

--- a/ams/opt/constraint.py
+++ b/ams/opt/constraint.py
@@ -37,18 +37,24 @@ class Constraint(OptzBase):
     name : str, optional
         A user-defined name for the constraint.
     e_str : str, optional
-        A mathematical expression representing the constraint (legacy form).
+        Mathematical expression in canonical CVXPY syntax with the
+        relational operator embedded — ``'<LHS> <= 0'``,
+        ``'<LHS> == 0'``, or ``'<LHS> >= 0'``. Authoring style is
+        LHS-zero: keep all terms on the left so ``.v`` reports
+        slack-from-zero (negative = respected, positive = violated)
+        uniformly across every constraint. CVXPY canonicalizes
+        every inequality to ``lhs - rhs <= 0`` internally regardless
+        of operator direction. Strict ``<`` / ``>`` are forbidden by
+        CVXPY (raises ``NotImplementedError``).
     e_fn : callable, optional
-        Callable ``e_fn(r) -> cp.Constraint`` taking a :class:`RoutineNS`.
+        Callable ``e_fn(r) -> cp.Constraint`` taking a
+        :class:`RoutineNS`. Must return a fully-formed
+        ``cp.constraints.Constraint`` (the codegen convention of
+        returning a bare LHS expression is no longer supported —
+        the routine source is now the single source of truth for
+        the relational shape).
     info : str, optional
         Additional informational text about the constraint.
-    is_eq : str, optional
-        Flag indicating if the constraint is an equality constraint. False indicates
-        an inequality constraint in the form of ``<= 0``. Honored for both the
-        ``e_str`` form and the codegen ``e_fn`` form (which returns only the LHS
-        — :meth:`evaluate` then applies ``== 0`` or ``<= 0`` based on this flag).
-        It is *only* ignored when an author manually passes an ``e_fn`` that
-        returns a fully-formed ``cp.Constraint``.
 
     Attributes
     ----------
@@ -56,8 +62,6 @@ class Constraint(OptzBase):
         Flag indicating if the constraint is disabled, False by default.
     rtn : ams.routines.Routine
         The owner routine instance.
-    is_disabled : bool, optional
-        Flag indicating if the constraint is disabled, False by default.
     code : str, optional
         The code string for the constraint
     """
@@ -70,14 +74,12 @@ class Constraint(OptzBase):
                  e_str: Optional[str] = None,
                  e_fn: Optional[Callable] = None,
                  info: Optional[str] = None,
-                 is_eq: Optional[bool] = False,
                  ):
         OptzBase.__init__(self, name=name, info=info)
         self._e_str = None
         self._e_fn = None
         self.e_str = e_str
         self.e_fn = e_fn
-        self.is_eq = is_eq
         self.is_disabled = False
         self.code = None
 
@@ -112,13 +114,14 @@ class Constraint(OptzBase):
         """
         Evaluate the constraint.
 
-        ``e_fn(r)`` may return either a fully-formed ``cp.Constraint``
-        (legacy convention; ``r.pg <= 0``) or just the LHS expression
-        (codegen convention; ``r.pg``). When it returns the LHS, the
-        relational op is applied here based on ``is_eq``. The LHS form
-        is required for ``.e`` to recover a numpy LHS during a failed
-        solve — see ``OptzBase.e``. The ``e_str`` path goes through
-        :func:`eval_e_str` and is wrapped the same way.
+        Both the ``e_fn`` (codegen) and ``e_str`` (eval-fallback)
+        paths must return a fully-formed ``cp.constraints.Constraint`` —
+        the relational operator lives in the source ``e_str`` (or in
+        the body of an author-supplied ``e_fn``), not in any
+        out-of-band flag. ``Constraint.v`` then reads
+        ``self.optz._expr.value`` which CVXPY canonicalizes to the
+        slack-from-zero LHS regardless of whether the author wrote
+        ``<=`` or ``>=``.
         """
         if self.e_fn is not None:
             try:
@@ -130,10 +133,14 @@ class Constraint(OptzBase):
             msg = f" - Constr <{self.name}>: {self.e_str}"
             logger.debug(pretty_long_message(msg, _prefix, max_length=_max_length))
             result = eval_e_str(self, self.e_str)
-        if isinstance(result, cp.constraints.Constraint):
-            self.optz = result
-        else:
-            self.optz = (result == 0) if self.is_eq else (result <= 0)
+        if not isinstance(result, cp.constraints.Constraint):
+            raise TypeError(
+                f"Constraint <{self.name}> e_str/e_fn must produce a "
+                f"cp.constraints.Constraint (embed the relational "
+                f"operator: '<LHS> <= 0', '<LHS> == 0', or '<LHS> >= 0'). "
+                f"Got {type(result).__name__}."
+            )
+        self.optz = result
         return True
 
     def __repr__(self):

--- a/ams/opt/optzbase.py
+++ b/ams/opt/optzbase.py
@@ -260,69 +260,65 @@ class OptzBase:
 
         Two paths:
 
-        - **e_fn form**: ``self.code`` is ``None`` because no string was
-          parsed; fall back to the cvxpy object's value (``self.optz._expr``
-          for constraints, ``self.optz`` otherwise). This is the
-          solver-returned value, not a re-canonicalization from current
-          parameter state — sufficient for the post-solve ``v == e`` check.
-        - **e_str form**: route through :func:`eval_e_str_numeric`,
-          which mirrors the symbol-resolution surface of the CVXPY-side
-          helper but resolves to numpy via :class:`NumericRoutineNS`.
+        - **e_str available** (codegen-wired or eval-fallback): defer
+          to :func:`eval_e_str_numeric`, which strips any embedded
+          relational operator so the result is always the LHS slack
+          (matches what ``.v`` reports via CVXPY canonicalization).
+          ``e_str`` is preserved on items even after codegen wires
+          ``e_fn`` — so this path is the canonical numeric route for
+          built-in routines.
+        - **e_fn-only** (rare; user-supplied callable with no
+          ``e_str``): re-evaluate against ``NumericRoutineNS`` and
+          extract the LHS depending on what the callable returns.
         """
-        if self.code is None:
-            # e_fn form: re-evaluate against the current numeric state
-            # via NumericRoutineNS. Resolves Vars to ``Var.v`` (which
-            # falls back to ``np.zeros`` when ``optz.value`` is None),
-            # so ``.e`` is informative even on a failed/incomplete
-            # solve — matching the legacy val_map+eval behavior.
-            #
-            # The e_fn may return: (a) a cp.Constraint (legacy form),
-            # (b) a cp.Expression (LHS or Objective inner), or (c) a
-            # pure numpy result when every operand is numpy and no
-            # cp.X wrapper is present. Handle all three.
-            from ams.core.routine_ns import NumericRoutineNS
-            e_fn = getattr(self, 'e_fn', None)
-            if e_fn is not None:
-                try:
-                    result = e_fn(NumericRoutineNS(self.om.rtn))
-                except Exception as exc:
-                    logger.error(
-                        f"Error in re-evaluating {self.class_name} "
-                        f"<{self.name}> via e_fn for `.e`.\n{exc}"
-                    )
-                    return None
-                # Constraint legacy form: extract LHS via _expr.value.
-                if isinstance(result, cp.constraints.Constraint):
-                    inner = getattr(result, '_expr', None)
-                    if inner is None:
-                        # Some constraint subclasses expose ``args[0]``
-                        inner = result.args[0] if result.args else None
-                    return getattr(inner, 'value', None)
-                # cp.Expression / cp.Constant: take .value.
-                if hasattr(result, 'value'):
-                    return result.value
-                # Pure numpy: that IS the value.
-                return result
-
-            # No e_fn either — fall back to cached optz.
-            optz = getattr(self, 'optz', None)
-            if optz is None:
-                logger.info(f"{self.class_name} <{self.name}> is not evaluated yet.")
+        if self.e_str is not None:
+            # e_str-driven numeric path. Operator-stripping happens
+            # inside ``eval_e_str_numeric``.
+            from ams.opt._runtime_eval import eval_e_str_numeric
+            try:
+                result = eval_e_str_numeric(self, self.e_str)
+            except Exception as exc:
+                logger.error(f"Error in calculating {self.class_name} <{self.name}>.\n{exc}")
                 return None
-            inner = getattr(optz, '_expr', optz)
-            return getattr(inner, 'value', None)
+            return getattr(result, 'value', result)
 
-        # e_str form: defer to the numeric helper. Same name-resolution
-        # surface as the CVXPY-side ``eval_e_str``, but values come from
-        # ``NumericRoutineNS`` so the result is a ``cp.Constant`` whose
-        # ``.value`` is the numpy LHS.
-        from ams.opt._runtime_eval import eval_e_str_numeric
-        try:
-            result = eval_e_str_numeric(self, self.code)
-        except Exception as exc:
-            logger.error(f"Error in calculating {self.class_name} <{self.name}>.\n{exc}")
+        # e_fn-only form: no e_str preserved on the item. Re-evaluate
+        # against the current numeric state via NumericRoutineNS.
+        # Resolves Vars to ``Var.v`` (which falls back to ``np.zeros``
+        # when ``optz.value`` is None), so ``.e`` is informative even
+        # on a failed/incomplete solve.
+        #
+        # The e_fn may return: (a) a cp.Constraint, (b) a cp.Expression
+        # (Objective inner), or (c) a pure numpy result when every
+        # operand is numpy and no cp.X wrapper is present.
+        from ams.core.routine_ns import NumericRoutineNS
+        e_fn = getattr(self, 'e_fn', None)
+        if e_fn is not None:
+            try:
+                result = e_fn(NumericRoutineNS(self.om.rtn))
+            except Exception as exc:
+                logger.error(
+                    f"Error in re-evaluating {self.class_name} "
+                    f"<{self.name}> via e_fn for `.e`.\n{exc}"
+                )
+                return None
+            # Constraint result: extract LHS via _expr.value.
+            if isinstance(result, cp.constraints.Constraint):
+                inner = getattr(result, '_expr', None)
+                if inner is None:
+                    inner = result.args[0] if result.args else None
+                return getattr(inner, 'value', None)
+            if hasattr(result, 'value'):
+                return result.value
+            return result
+
+        # No e_str, no e_fn — fall back to cached optz.
+        optz = getattr(self, 'optz', None)
+        if optz is None:
+            logger.info(f"{self.class_name} <{self.name}> is not evaluated yet.")
             return None
-        return getattr(result, 'value', result)
+        inner = getattr(optz, '_expr', optz)
+        return getattr(inner, 'value', None)
 
     def __repr__(self):
         return f'{self.__class__.__name__}: {self.name}'

--- a/ams/prep/generator.py
+++ b/ams/prep/generator.py
@@ -106,6 +106,15 @@ _TEX_TEMPLATES = OrderedDict([
     (r'\bsum\b', 'SUM'),
     (r'power\((.*?),\s*(\d+)\)', r'\1^\2'),
     (r'(\w+).dual_variables\[0\]', r'\phi[\1]'),
+    # Relational operators must come AFTER the `\bcp.X` stripper above
+    # but ordering within this trio doesn't matter (no overlap among
+    # `<=`, `>=`, `==`). `==` -> `=` because `\eq` would be ambiguous
+    # under math-mode rendering. Replacements use double-backslash so
+    # `re.sub` emits a literal `\leq` / `\geq` (single-backslash forms
+    # raise re.PatternError on Python 3.12+).
+    (r'<=', r'\\leq'),
+    (r'>=', r'\\geq'),
+    (r'==', '='),
 ])
 
 
@@ -319,11 +328,12 @@ def generate_for_routine(routine, *, header_extra: str = '') -> str:
         parts.append('\n')
 
     # --- Constraints ---
-    # Codegen convention: emit the LHS expression only. Constraint.evaluate
-    # applies ``<= 0`` / ``== 0`` based on ``is_eq``. This lets ``.e`` recover
-    # a numpy LHS during a failed/incomplete solve via ``NumericRoutineNS``;
-    # the legacy ``return <body> <= 0`` form short-circuits to a numpy bool
-    # when every operand is numpy, which loses the LHS.
+    # Codegen emits the rewritten ``e_str`` verbatim — relational operator
+    # included (post `is_eq` retirement). The wired callable returns a
+    # ``cp.constraints.Constraint``; ``Constraint.evaluate`` stores it
+    # directly. ``.e`` recovers the numpy LHS via ``optz._expr.value``,
+    # which CVXPY canonicalizes to ``lhs - rhs`` for any inequality
+    # direction — same diagnostic semantics as the prior LHS-only emit.
     for name, constr in routine.constrs.items():
         if constr.e_fn is not None or constr.e_str is None:
             continue

--- a/ams/prep/generator.py
+++ b/ams/prep/generator.py
@@ -35,7 +35,7 @@ import ams
 # value, forcing a regen on the next run. Older caches that predate the
 # field (no attribute) are likewise rejected. Auto-heal pattern: same
 # as the ``pristine`` marker added in PR #242.
-PYCODE_FORMAT_VERSION = 2
+PYCODE_FORMAT_VERSION = 3
 
 
 # Routine symbol names that would silently shadow a CVXPY atom in the

--- a/ams/routines/dcopf.py
+++ b/ams/routines/dcopf.py
@@ -121,23 +121,19 @@ class DCOPF(DCPFBase):
                                 e_str='cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmin)',
                                 model='StaticGen', src=None, unit='p.u.',)
         self.pglb = Constraint(name='pglb', info='pg min',
-                               e_str='-pg + pmine', is_eq=False,)
+                               e_str='-pg + pmine <= 0', )
         self.pgub = Constraint(name='pgub', info='pg max',
-                               e_str='pg - pmaxe', is_eq=False,)
+                               e_str='pg - pmaxe <= 0', )
 
         # --- line flow ---
         self.plflb = Constraint(info='line flow lower bound',
-                                name='plflb', is_eq=False,
-                                e_str='-plf - cp.multiply(ul, rate_a)',)
+                                name='plflb', e_str='-plf - cp.multiply(ul, rate_a) <= 0',)
         self.plfub = Constraint(info='line flow upper bound',
-                                name='plfub', is_eq=False,
-                                e_str='plf - cp.multiply(ul, rate_a)',)
+                                name='plfub', e_str='plf - cp.multiply(ul, rate_a) <= 0',)
         self.alflb = Constraint(info='line angle difference lower bound',
-                                name='alflb', is_eq=False,
-                                e_str='-CftT@aBus + amin',)
+                                name='alflb', e_str='-CftT@aBus + amin <= 0',)
         self.alfub = Constraint(info='line angle difference upper bound',
-                                name='alfub', is_eq=False,
-                                e_str='CftT@aBus - amax',)
+                                name='alfub', e_str='CftT@aBus - amax <= 0',)
         # NOTE: in CVXPY, dual_variables returns a list
         self.pi = ExpressionCalc(info='LMP, dual of <pb>',
                                  name='pi', unit='$/p.u.',

--- a/ams/routines/dcopf2.py
+++ b/ams/routines/dcopf2.py
@@ -45,7 +45,7 @@ class PTDFBase:
 
         # --- rewrite Constraint pb: power balance ---
         # PTDF formulation uses system-wide balance instead of nodal balance
-        self.pb.e_str = "cp.sum(pg) - cp.sum(pd)"
+        self.pb.e_str = "cp.sum(pg) - cp.sum(pd) == 0"
 
         # --- rewrite Expression plf: line flow---
         # Use PTDF matrix instead of Bf@aBus

--- a/ams/routines/dcpf.py
+++ b/ams/routines/dcpf.py
@@ -108,9 +108,9 @@ class DCPFBase(RoutineBase):
                         model='Bus', src='a',)
 
         # --- power balance ---
-        pb = 'Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg'
+        pb = 'Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg == 0'
         self.pb = Constraint(name='pb', info='power balance',
-                             e_str=pb, is_eq=True,)
+                             e_str=pb,)
 
         # --- bus ---
         self.isb = VarSelect(info='Index slack bus from all buses',
@@ -118,8 +118,7 @@ class DCPFBase(RoutineBase):
                              u=self.aBus, indexer='buss',
                              no_parse=True,)
         self.sba = Constraint(info='align slack bus angle',
-                              name='sbus', is_eq=True,
-                              e_str='isb@aBus',)
+                              name='sbus', e_str='isb@aBus == 0',)
 
         # --- line flow ---
         self.plf = Expression(info='Line flow',
@@ -204,8 +203,8 @@ class DCPF(DCPFBase):
                              no_parse=True,)
 
         self.pvb = Constraint(name='pvb', info='PV generator',
-                              e_str='ipv @ (pg - cp.multiply(ug, pg0))',
-                              is_eq=True,)
+                              e_str='ipv @ (pg - cp.multiply(ug, pg0)) == 0',
+                              )
 
         self.obj = Objective(name='obj',
                              info='place holder', unit='$',

--- a/ams/routines/dopf.py
+++ b/ams/routines/dopf.py
@@ -63,12 +63,10 @@ class DOPF(DCOPF):
         self.qg = Var(info='Gen reactive power',
                       name='qg', tex_name=r'q_{g}', unit='p.u.',
                       model='StaticGen', src='q',)
-        self.qglb = Constraint(name='qglb', is_eq=False,
-                               info='qg min',
-                               e_str='-qg + cp.multiply(ug, qmin)',)
-        self.qgub = Constraint(name='qgub', is_eq=False,
-                               info='qg max',
-                               e_str='qg - cp.multiply(ug, qmax)',)
+        self.qglb = Constraint(name='qglb', info='qg min',
+                               e_str='-qg + cp.multiply(ug, qmin) <= 0',)
+        self.qgub = Constraint(name='qgub', info='qg max',
+                               e_str='qg - cp.multiply(ug, qmax) <= 0',)
         # --- bus ---
         self.v = Var(info='Bus voltage',
                      name='v', tex_name=r'v',
@@ -79,25 +77,23 @@ class DOPF(DCOPF):
                        model='Bus',)
         self.vu = Constraint(name='vu',
                              info='Voltage upper limit',
-                             e_str='vsq - vmax**2',
-                             is_eq=False,)
+                             e_str='vsq - vmax**2 <= 0',
+                             )
         self.vl = Constraint(name='vl',
                              info='Voltage lower limit',
-                             e_str='-vsq + vmin**2',
-                             is_eq=False,)
+                             e_str='-vsq + vmin**2 <= 0',
+                             )
         # --- line ---
         self.qlf = Var(info='line reactive power',
                        name='qlf', tex_name=r'q_{lf}',
                        unit='p.u.', model='Line',)
         self.lvd = Constraint(info='line voltage drop',
-                              name='lvd', is_eq=True,
-                              e_str='CftT@vsq - (cp.multiply(r, plf) + cp.multiply(x, qlf))',)
+                              name='lvd', e_str='CftT@vsq - (cp.multiply(r, plf) + cp.multiply(x, qlf)) == 0',)
         # --- power balance ---
         # NOTE: following Eqn seems to be wrong, double check
         # g_Q(\Theta, V, Q_g) = B_{bus}V\Theta + Q_{bus,shift} + Q_d + B_{sh} - C_gQ_g = 0
         self.qb = Constraint(info='reactive power balance',
-                             name='qb', is_eq=True,
-                             e_str='cp.sum(qd) - cp.sum(qg)',)
+                             name='qb', e_str='cp.sum(qd) - cp.sum(qg) == 0',)
 
         # --- objective ---
         # NOTE: no need to revise objective function

--- a/ams/routines/ed.py
+++ b/ams/routines/ed.py
@@ -46,9 +46,9 @@ class SRBase:
 
         # NOTE: define e_str in the scheduling model
         self.prsb = Constraint(info='spinning reserve balance',
-                               name='prsb', is_eq=True,)
+                               name='prsb',)
         self.rsr = Constraint(info='spinning reserve requirement',
-                              name='rsr', is_eq=False,)
+                              name='rsr',)
 
 
 class MPBase:
@@ -163,8 +163,8 @@ class ED(SRBase, MPBase, RTED):
         pmine = 'cp.multiply(cp.multiply(nctrle, pg0), tlv) + cp.multiply(cp.multiply(ctrle, tlv), pmin)'
         self.pmine.e_str = pmine
         self.pmine.horizon = self.timeslot
-        self.pglb.e_str = '-pg + pmine'
-        self.pgub.e_str = 'pg - pmaxe'
+        self.pglb.e_str = '-pg + pmine <= 0'
+        self.pgub.e_str = 'pg - pmaxe <= 0'
 
         self.pru.horizon = self.timeslot
         self.pru.info = '2D RegUp power'
@@ -172,40 +172,40 @@ class ED(SRBase, MPBase, RTED):
         self.prd.info = '2D RegDn power'
 
         self.prs.horizon = self.timeslot
-        self.prsb.e_str = 'cp.multiply(ugt, pmax@tlv - pg) - prs'
-        self.rsr.e_str = '-gs@prs + dsr'
+        self.prsb.e_str = 'cp.multiply(ugt, pmax@tlv - pg) - prs == 0'
+        self.rsr.e_str = '-gs@prs + dsr <= 0'
 
         # --- line ---
         self.plf.horizon = self.timeslot
         self.plf.info = '2D Line flow'
-        self.plflb.e_str = '-Bf@aBus - Pfinj@tlv - cp.multiply(ul, rate_a)@tlv'
-        self.plfub.e_str = 'Bf@aBus + Pfinj@tlv - cp.multiply(ul, rate_a)@tlv'
-        self.alflb.e_str = '-CftT@aBus + amin@tlv'
-        self.alfub.e_str = 'CftT@aBus - amax@tlv'
+        self.plflb.e_str = '-Bf@aBus - Pfinj@tlv - cp.multiply(ul, rate_a)@tlv <= 0'
+        self.plfub.e_str = 'Bf@aBus + Pfinj@tlv - cp.multiply(ul, rate_a)@tlv <= 0'
+        self.alflb.e_str = '-CftT@aBus + amin@tlv <= 0'
+        self.alfub.e_str = 'CftT@aBus - amax@tlv <= 0'
 
         self.plf.e_str = 'Bf@aBus + Pfinj@tlv'
 
         # --- power balance ---
-        self.pb.e_str = 'Bbus@aBus + Pbusinj@tlv + Cl@pds + Csh@gsh@tlv - Cg@pg'
+        self.pb.e_str = 'Bbus@aBus + Pbusinj@tlv + Cl@pds + Csh@gsh@tlv - Cg@pg == 0'
 
         # --- ramping ---
-        self.rbu.e_str = 'gs@cp.multiply(ugt, pru) - cp.multiply(dud, tlv)'
-        self.rbd.e_str = 'gs@cp.multiply(ugt, prd) - cp.multiply(ddd, tlv)'
+        self.rbu.e_str = 'gs@cp.multiply(ugt, pru) - cp.multiply(dud, tlv) == 0'
+        self.rbd.e_str = 'gs@cp.multiply(ugt, prd) - cp.multiply(ddd, tlv) == 0'
 
-        self.rru.e_str = 'pg + pru - cp.multiply(cp.multiply(ugt, pmax), tlv)'
-        self.rrd.e_str = '-pg + prd + cp.multiply(cp.multiply(ugt, pmin), tlv)'
+        self.rru.e_str = 'pg + pru - cp.multiply(cp.multiply(ugt, pmax), tlv) <= 0'
+        self.rrd.e_str = '-pg + prd + cp.multiply(cp.multiply(ugt, pmin), tlv) <= 0'
 
-        self.rgu.e_str = 'pg @ Mr - t * RR30'
-        self.rgd.e_str = '-pg @ Mr - t * RR30'
+        self.rgu.e_str = 'pg @ Mr - t * RR30 <= 0'
+        self.rgd.e_str = '-pg @ Mr - t * RR30 <= 0'
 
         self.rgu0 = Constraint(name='rgu0',
                                info='Initial gen ramping up',
-                               e_str='cp.multiply(ugt[:, 0], pg[:, 0] - pg0[:, 0] - R30)',
-                               is_eq=False,)
+                               e_str='cp.multiply(ugt[:, 0], pg[:, 0] - pg0[:, 0] - R30) <= 0',
+                               )
         self.rgd0 = Constraint(name='rgd0',
                                info='Initial gen ramping down',
-                               e_str='cp.multiply(ugt[:, 0], -pg[:, 0] + pg0[:, 0] - R30)',
-                               is_eq=False,)
+                               e_str='cp.multiply(ugt[:, 0], -pg[:, 0] + pg0[:, 0] - R30) <= 0',
+                               )
 
         # --- objective ---
         cost = 'cp.sum(t**2 * c2 @ pg**2)'
@@ -276,16 +276,16 @@ class ESD1MPBase(ESD1Base):
                                 name='REtaDR', tex_name=r'R_{\eta_d,R}',
                                 info='Repeated REtaD as 2D matrix, (ng, ng-1)')
         SOCb = 'cp.multiply(EnR, SOC @ Mre) - t * cp.multiply(EtaCR, pce[:, 1:])'
-        SOCb += ' + t * cp.multiply(REtaDR, pde[:, 1:])'
+        SOCb += ' + t * cp.multiply(REtaDR, pde[:, 1:]) == 0'
         self.SOCb.e_str = SOCb
 
         SOCb0 = 'cp.multiply(En, SOC[:, 0] - SOCinit) - t * cp.multiply(EtaC, pce[:, 0])'
-        SOCb0 += ' + t * cp.multiply(REtaD, pde[:, 0])'
-        self.SOCb0 = Constraint(name='SOCb0', is_eq=True,
+        SOCb0 += ' + t * cp.multiply(REtaD, pde[:, 0]) == 0'
+        self.SOCb0 = Constraint(name='SOCb0',
                                 info='ESD1 SOC initial balance',
                                 e_str=SOCb0,)
 
-        self.SOCr.e_str = 'SOCend - SOC[:, -1]'
+        self.SOCr.e_str = 'SOCend - SOC[:, -1] <= 0'
 
         # NOTE: extend vars to 2D
         self.pgdg.horizon = self.timeslot

--- a/ams/routines/ed2.py
+++ b/ams/routines/ed2.py
@@ -19,7 +19,7 @@ class PTDFMPBase(PTDFBase):
         super().__init__(system, config, **kwargs)
 
         # rewrite pb to ensure power balance for each period
-        self.pb.e_str = "cp.sum(pg, axis=0) - cp.sum(pds, axis=0)"
+        self.pb.e_str = "cp.sum(pg, axis=0) - cp.sum(pds, axis=0) == 0"
 
         # --- rewrite Expression plf: line flow---
         self.plf.e_str = "PTDF @ (Cg@pg - Cl@pds - Csh@gsh@tlv - Pbusinj@tlv)"

--- a/ams/routines/pflow.py
+++ b/ams/routines/pflow.py
@@ -212,8 +212,7 @@ class PFlow(RoutineBase):
     def addConstrs(self,
                    name: str,
                    e_str: str,
-                   info: Optional[str] = None,
-                   is_eq: Optional[str] = False,):
+                   info: Optional[str] = None,):
         """
         Not supported!
         """

--- a/ams/routines/pypower.py
+++ b/ams/routines/pypower.py
@@ -358,8 +358,7 @@ class DCPF1(RoutineBase):
     def addConstrs(self,
                    name: str,
                    e_str: str,
-                   info: Optional[str] = None,
-                   is_eq: Optional[str] = False,):
+                   info: Optional[str] = None,):
         raise NotImplementedError
 
     def addVars(self,

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -1240,27 +1240,28 @@ class RoutineBase:
     def addConstrs(self,
                    name: str,
                    e_str: str,
-                   info: Optional[str] = None,
-                   is_eq: Optional[str] = False,):
+                   info: Optional[str] = None,):
         """
         Add a `Constraint` to the routine at runtime.
 
         ``e_str`` must use canonical CVXPY syntax — call ``cp.multiply``,
-        ``cp.sum``, ``cp.power`` etc. directly. The historical AMS DSL
-        (``mul``, ``multiply``, ``sum``, ``a dot b``) was removed in
-        v1.2.2; see :ref:`migration_cvxpy_namespace`.
+        ``cp.sum``, ``cp.power`` etc. directly — and embed the
+        relational operator. Author every term on the left so the
+        suffix is one of ``' <= 0'``, ``' == 0'``, or ``' >= 0'``.
+        This LHS-zero discipline keeps ``constr.v`` reporting
+        slack-from-zero (negative = respected, positive = violated).
 
         Examples
         --------
         Append a hard generation cap::
 
             sp.RTED.addConstrs(name='pg_cap',
-                               e_str='pg - pmax')
+                               e_str='pg - pmax <= 0')
 
-        Equivalent with an embedded relational operator (post-v1.2.2)::
+        Force two variables equal::
 
-            sp.RTED.addConstrs(name='pg_cap',
-                               e_str='pg <= pmax')
+            sp.RTED.addConstrs(name='pg_match',
+                               e_str='pg - pset == 0')
 
         Parameters
         ----------
@@ -1269,14 +1270,12 @@ class RoutineBase:
             name used in expressions; pick a name that does not collide
             with a CVXPY atom (``sum``, ``multiply``, ``vstack``, …).
         e_str : str
-            Constraint expression string in canonical CVXPY syntax.
+            Constraint expression string in canonical CVXPY syntax,
+            with the relational operator embedded.
         info : str, optional
             Descriptive information
-        is_eq : str, optional
-            Flag indicating if the constraint is an equality constraint. False indicates
-            an inequality constraint in the form of `<= 0`.
         """
-        item = Constraint(name=name, e_str=e_str, info=info, is_eq=is_eq)
+        item = Constraint(name=name, e_str=e_str, info=info)
         # add the constraint as an routine attribute
         setattr(self, name, item)
 

--- a/ams/routines/rted.py
+++ b/ams/routines/rted.py
@@ -57,17 +57,17 @@ class SFRBase:
                        unit='p.u.', name='prd', tex_name=r'p_{r,d}',
                        model='StaticGen', nonneg=True,)
         # NOTE: define e_str in scheduling routine
-        self.rbu = Constraint(name='rbu', is_eq=True,
+        self.rbu = Constraint(name='rbu',
                               info='RegUp reserve balance',)
-        self.rbd = Constraint(name='rbd', is_eq=True,
+        self.rbd = Constraint(name='rbd',
                               info='RegDn reserve balance',)
-        self.rru = Constraint(name='rru', is_eq=False,
+        self.rru = Constraint(name='rru',
                               info='RegUp reserve source',)
-        self.rrd = Constraint(name='rrd', is_eq=False,
+        self.rrd = Constraint(name='rrd',
                               info='RegDn reserve source',)
-        self.rgu = Constraint(name='rgu', is_eq=False,
+        self.rgu = Constraint(name='rgu',
                               info='Gen ramping up',)
-        self.rgd = Constraint(name='rgd', is_eq=False,
+        self.rgd = Constraint(name='rgd',
                               info='Gen ramping down',)
 
 
@@ -157,14 +157,14 @@ class RTED(SFRBase, RTEDBase, DCOPF):
         # --- Model Section ---
         # --- SFR ---
         # RegUp/Dn reserve balance
-        self.rbu.e_str = 'gs @ cp.multiply(ug, pru) - dud'
-        self.rbd.e_str = 'gs @ cp.multiply(ug, prd) - ddd'
+        self.rbu.e_str = 'gs @ cp.multiply(ug, pru) - dud == 0'
+        self.rbd.e_str = 'gs @ cp.multiply(ug, prd) - ddd == 0'
         # RegUp/Dn reserve source
-        self.rru.e_str = 'cp.multiply(ug, (pg + pru)) - cp.multiply(ug, pmaxe)'
-        self.rrd.e_str = 'cp.multiply(ug, (-pg + prd)) + cp.multiply(ug, pmine)'
+        self.rru.e_str = 'cp.multiply(ug, (pg + pru)) - cp.multiply(ug, pmaxe) <= 0'
+        self.rrd.e_str = 'cp.multiply(ug, (-pg + prd)) + cp.multiply(ug, pmine) <= 0'
         # Gen ramping up/down
-        self.rgu.e_str = 'cp.multiply(ug, (pg-pg0-R10))'
-        self.rgd.e_str = 'cp.multiply(ug, (-pg+pg0-R10))'
+        self.rgu.e_str = 'cp.multiply(ug, (pg-pg0-R10)) <= 0'
+        self.rgd.e_str = 'cp.multiply(ug, (-pg+pg0-R10)) <= 0'
 
         # --- objective ---
         self.obj.info = 'total generation and reserve cost'
@@ -258,9 +258,8 @@ class DGBase:
                              info='Index DG power from pg',
                              gamma='gammapdg',
                              no_parse=True, sparse=True,)
-        self.cdgb = Constraint(name='cdgb', is_eq=True,
-                               info='Select DG power from pg',
-                               e_str='idg @ pg - pgdg',)
+        self.cdgb = Constraint(name='cdgb', info='Select DG power from pg',
+                               e_str='idg @ pg - pgdg == 0',)
 
 
 class RTEDDG(DGBase, RTED):
@@ -354,26 +353,22 @@ class ESD1PBase:
                              name='ies', tex_name=r'I_{ESD}',
                              info='Index ESD from StaticGen',
                              no_parse=True)
-        self.cesd = Constraint(name='cesd', is_eq=True,
-                               info='Select pce and pde from pg',
-                               e_str='ies @ pg + pce - pde',)
+        self.cesd = Constraint(name='cesd', info='Select pce and pde from pg',
+                               e_str='ies @ pg + pce - pde == 0',)
 
-        self.SOClb = Constraint(name='SOClb', is_eq=False,
-                                info='SOC lower bound',
-                                e_str='-SOC + SOCmin',)
-        self.SOCub = Constraint(name='SOCub', is_eq=False,
-                                info='SOC upper bound',
-                                e_str='SOC - SOCmax',)
+        self.SOClb = Constraint(name='SOClb', info='SOC lower bound',
+                                e_str='-SOC + SOCmin <= 0',)
+        self.SOCub = Constraint(name='SOCub', info='SOC upper bound',
+                                e_str='SOC - SOCmax <= 0',)
 
         SOCb = 'cp.multiply(En, (SOC - SOCinit)) - t * cp.multiply(EtaC, pce)'
-        SOCb += '+ t * cp.multiply(REtaD, pde)'
-        self.SOCb = Constraint(name='SOCb', is_eq=True,
+        SOCb += '+ t * cp.multiply(REtaD, pde) == 0'
+        self.SOCb = Constraint(name='SOCb',
                                info='ESD1 SOC balance',
                                e_str=SOCb,)
 
-        self.SOCr = Constraint(name='SOCr', is_eq=False,
-                               info='ESD1 final SOC requirement',
-                               e_str='SOCend - SOC',)
+        self.SOCr = Constraint(name='SOCr', info='ESD1 final SOC requirement',
+                               e_str='SOCend - SOC <= 0',)
 
         self.obj.e_str += '+ t * cp.sum(- cp.multiply(cesdc, pce) + cp.multiply(cesdd, pde))'
 
@@ -436,11 +431,11 @@ class RTEDESP(ESD1PBase, RTEDDG):
                           tex_name=r'u_{d,ESD}',
                           model='ESD1', no_parse=True,)
 
-        self.zce = Constraint(name='zce', is_eq=False, info='zce bound',
-                              e_str='cp.multiply(1-ucd, pce)',)
+        self.zce = Constraint(name='zce', info='zce bound',
+                              e_str='cp.multiply(1-ucd, pce) <= 0',)
 
-        self.zde = Constraint(name='zde', is_eq=False, info='zde bound',
-                              e_str='cp.multiply(1-udd, pde)',)
+        self.zde = Constraint(name='zde', info='zde bound',
+                              e_str='cp.multiply(1-udd, pde) <= 0',)
 
     def _preinit(self):
         """
@@ -513,33 +508,32 @@ class ESD1Base(DGBase, ESD1PBase):
         self.zde.info += ':math:`z_{d,ESD}=u_{d,ESD}*p_{d,ESD}`'
 
         # --- constraints ---
-        self.cdb = Constraint(name='cdb', is_eq=True,
-                              info='Charging decision bound',
-                              e_str='ucd + udd - 1',)
+        self.cdb = Constraint(name='cdb', info='Charging decision bound',
+                              e_str='ucd + udd - 1 == 0',)
 
-        self.zce1 = Constraint(name='zce1', is_eq=False, info='zce bound 1',
-                               e_str='-zce + pce',)
-        self.zce2 = Constraint(name='zce2', is_eq=False, info='zce bound 2',
-                               e_str='zce - pce - Mb * (1-ucd)',)
-        self.zce3 = Constraint(name='zce3', is_eq=False, info='zce bound 3',
-                               e_str='zce - Mb * ucd',)
+        self.zce1 = Constraint(name='zce1', info='zce bound 1',
+                               e_str='-zce + pce <= 0',)
+        self.zce2 = Constraint(name='zce2', info='zce bound 2',
+                               e_str='zce - pce - Mb * (1-ucd) <= 0',)
+        self.zce3 = Constraint(name='zce3', info='zce bound 3',
+                               e_str='zce - Mb * ucd <= 0',)
 
-        self.zde1 = Constraint(name='zde1', is_eq=False, info='zde bound 1',
-                               e_str='-zde + pde',)
-        self.zde2 = Constraint(name='zde2', is_eq=False, info='zde bound 2',
-                               e_str='zde - pde - Mb * (1-udd)',)
-        self.zde3 = Constraint(name='zde3', is_eq=False, info='zde bound 3',
-                               e_str='zde - Mb * udd',)
+        self.zde1 = Constraint(name='zde1', info='zde bound 1',
+                               e_str='-zde + pde <= 0',)
+        self.zde2 = Constraint(name='zde2', info='zde bound 2',
+                               e_str='zde - pde - Mb * (1-udd) <= 0',)
+        self.zde3 = Constraint(name='zde3', info='zde bound 3',
+                               e_str='zde - Mb * udd <= 0',)
 
         # force charging flag `fcd`: (tdc0 > 0) * (tdc > tdc0)
-        tcdr = '(tdc0 > 0) * (tdc > tdc0) - ucd'
-        self.tcdr = Constraint(name='tcdr', is_eq=False,
+        tcdr = '(tdc0 > 0) * (tdc > tdc0) - ucd <= 0'
+        self.tcdr = Constraint(name='tcdr',
                                info='Minimum charging duration',
                                e_str=tcdr,)
 
         # force discharging flag `fdd`: (tdd0 > 0) * (tdd > tdd0)
-        tddr = '(tdd0 > 0) * (tdd > tdd0) - udd'
-        self.tddr = Constraint(name='tddr', is_eq=False,
+        tddr = '(tdd0 > 0) * (tdd > tdd0) - udd <= 0'
+        self.tddr = Constraint(name='tddr',
                                info='Minimum discharging duration',
                                e_str=tddr,)
 
@@ -617,18 +611,14 @@ class VISBase:
                              name='gvsg', tex_name=r'S_{g}',
                              info='Sum VSG vars vector in shape of area',
                              no_parse=True)
-        self.Mub = Constraint(name='Mub', is_eq=False,
-                              info='M upper bound',
-                              e_str='M - Mmax',)
-        self.Dub = Constraint(name='Dub', is_eq=False,
-                              info='D upper bound',
-                              e_str='D - Dmax',)
-        self.Mreq = Constraint(name='Mreq', is_eq=True,
-                               info='Emulated inertia requirement',
-                               e_str='-gvsg@M + dvm',)
-        self.Dreq = Constraint(name='Dreq', is_eq=True,
-                               info='Emulated damping requirement',
-                               e_str='-gvsg@D + dvd',)
+        self.Mub = Constraint(name='Mub', info='M upper bound',
+                              e_str='M - Mmax <= 0',)
+        self.Dub = Constraint(name='Dub', info='D upper bound',
+                              e_str='D - Dmax <= 0',)
+        self.Mreq = Constraint(name='Mreq', info='Emulated inertia requirement',
+                               e_str='-gvsg@M + dvm == 0',)
+        self.Dreq = Constraint(name='Dreq', info='Emulated damping requirement',
+                               e_str='-gvsg@D + dvd == 0',)
 
         # NOTE: revise the objective function to include virtual inertia cost
 

--- a/ams/routines/uc.py
+++ b/ams/routines/uc.py
@@ -49,9 +49,9 @@ class NSRBase:
 
         # NOTE: define e_str in dispatch model
         self.prnsb = Constraint(info='non-spinning reserve balance',
-                                name='prnsb', is_eq=True,)
+                                name='prnsb',)
         self.rnsr = Constraint(info='non-spinning reserve requirement',
-                               name='rnsr', is_eq=False,)
+                               name='rnsr',)
 
 
 class UC(SRBase, NSRBase, MPBase, RTEDBase, DCOPF):
@@ -154,8 +154,8 @@ class UC(SRBase, NSRBase, MPBase, RTEDBase, DCOPF):
         pmine = 'cp.multiply(cp.multiply(ctrl, pmin), ugd) + cp.multiply(cp.multiply(nctrl, pg0), ugd)'
         self.pmine.e_str = pmine
         self.pmine.horizon = self.timeslot
-        self.pglb.e_str = '-pg + pmine'
-        self.pgub.e_str = 'pg - pmaxe'
+        self.pglb.e_str = '-pg + pmine <= 0'
+        self.pgub.e_str = 'pg - pmaxe <= 0'
 
         self.ugd = Var(info='commitment decision',
                        horizon=self.timeslot,
@@ -177,18 +177,14 @@ class UC(SRBase, NSRBase, MPBase, RTEDBase, DCOPF):
                        name='zug', tex_name=r'z_{ug}',
                        model='StaticGen', pos=True,)
         # NOTE: actions have two parts: initial status and the rest
-        self.actv = Constraint(name='actv', is_eq=True,
-                               info='startup action',
-                               e_str='ugd @ Mr - vgd[:, 1:]',)
-        self.actv0 = Constraint(name='actv0', is_eq=True,
-                                info='initial startup action',
-                                e_str='ugd[:, 0] - ug[:, 0]  - vgd[:, 0]',)
-        self.actw = Constraint(name='actw', is_eq=True,
-                               info='shutdown action',
-                               e_str='-ugd @ Mr - wgd[:, 1:]',)
-        self.actw0 = Constraint(name='actw0', is_eq=True,
-                                info='initial shutdown action',
-                                e_str='-ugd[:, 0] + ug[:, 0] - wgd[:, 0]',)
+        self.actv = Constraint(name='actv', info='startup action',
+                               e_str='ugd @ Mr - vgd[:, 1:] == 0',)
+        self.actv0 = Constraint(name='actv0', info='initial startup action',
+                                e_str='ugd[:, 0] - ug[:, 0]  - vgd[:, 0] == 0',)
+        self.actw = Constraint(name='actw', info='shutdown action',
+                               e_str='-ugd @ Mr - wgd[:, 1:] == 0',)
+        self.actw0 = Constraint(name='actw0', info='initial shutdown action',
+                                e_str='-ugd[:, 0] + ug[:, 0] - wgd[:, 0] == 0',)
 
         self.prs.horizon = self.timeslot
         self.prs.info = '2D Spinning reserve'
@@ -197,14 +193,14 @@ class UC(SRBase, NSRBase, MPBase, RTEDBase, DCOPF):
         self.prns.info = '2D Non-spinning reserve'
 
         # spinning reserve
-        self.prsb.e_str = 'cp.multiply(ugd, cp.multiply(pmax, tlv)) - zug - prs'
+        self.prsb.e_str = 'cp.multiply(ugd, cp.multiply(pmax, tlv)) - zug - prs == 0'
         # spinning reserve requirement
-        self.rsr.e_str = '-gs@prs + dsr'
+        self.rsr.e_str = '-gs@prs + dsr <= 0'
 
         # non-spinning reserve
-        self.prnsb.e_str = 'cp.multiply(1-ugd, cp.multiply(pmax, tlv)) - prns'
+        self.prnsb.e_str = 'cp.multiply(1-ugd, cp.multiply(pmax, tlv)) - prns == 0'
         # non-spinning reserve requirement
-        self.rnsr.e_str = '-gs@prns + dnsr'
+        self.rnsr.e_str = '-gs@prns + dnsr <= 0'
 
         # --- big M for ugd*pg ---
         self.Mzug = NumOp(info='10 times of max of pmax as big M for zug',
@@ -213,33 +209,31 @@ class UC(SRBase, NSRBase, MPBase, RTEDBase, DCOPF):
                           rfun=np.dot, rargs=dict(b=10),
                           array_out=False,)
         self.zuglb = Constraint(name='zuglb', info='zug lower bound',
-                                is_eq=False, e_str='- zug + pg')
+                                e_str='- zug + pg <= 0')
         self.zugub = Constraint(name='zugub', info='zug upper bound',
-                                is_eq=False, e_str='zug - pg - Mzug * (1 - ugd)')
+                                e_str='zug - pg - Mzug * (1 - ugd) <= 0')
         self.zugub2 = Constraint(name='zugub2', info='zug upper bound',
-                                 is_eq=False, e_str='zug - Mzug * ugd')
+                                 e_str='zug - Mzug * ugd <= 0')
 
         # --- minimum ON/OFF duration ---
         self.Con = MinDur(u=self.pg, u2=self.td1,
                           name='Con', tex_name=r'T_{on}',
                           info='minimum ON coefficient',)
         self.don = Constraint(info='minimum online duration',
-                              name='don', is_eq=False,
-                              e_str='cp.multiply(Con, vgd) - ugd')
+                              name='don', e_str='cp.multiply(Con, vgd) - ugd <= 0')
         self.Coff = MinDur(u=self.pg, u2=self.td2,
                            name='Coff', tex_name=r'T_{off}',
                            info='minimum OFF coefficient',)
         self.doff = Constraint(info='minimum offline duration',
-                               name='doff', is_eq=False,
-                               e_str='cp.multiply(Coff, wgd) - (1 - ugd)')
+                               name='doff', e_str='cp.multiply(Coff, wgd) - (1 - ugd) <= 0')
 
         # --- line ---
         self.plf.horizon = self.timeslot
         self.plf.info = '2D Line flow'
-        self.plflb.e_str = '-Bf@aBus - Pfinj - cp.multiply(rate_a, tlv)'
-        self.plfub.e_str = 'Bf@aBus + Pfinj - cp.multiply(rate_a, tlv)'
-        self.alflb.e_str = '-CftT@aBus - amax@tlv'
-        self.alfub.e_str = 'CftT@aBus - amax@tlv'
+        self.plflb.e_str = '-Bf@aBus - Pfinj - cp.multiply(rate_a, tlv) <= 0'
+        self.plfub.e_str = 'Bf@aBus + Pfinj - cp.multiply(rate_a, tlv) <= 0'
+        self.alflb.e_str = '-CftT@aBus - amax@tlv <= 0'
+        self.alfub.e_str = 'CftT@aBus - amax@tlv <= 0'
 
         # --- unserved load ---
         self.pdu = Var(info='unserved demand',
@@ -252,11 +246,10 @@ class UC(SRBase, NSRBase, MPBase, RTEDBase, DCOPF):
                           info='positive demand',
                           name='pdsp', tex_name=r'p_{d,s}^{+}',)
         self.pdumax = Constraint(info='unserved demand upper bound',
-                                 name='pdumax', is_eq=False,
-                                 e_str='pdu - cp.multiply(pdsp, dctrl@tlv)')
+                                 name='pdumax', e_str='pdu - cp.multiply(pdsp, dctrl@tlv) <= 0')
         # --- power balance ---
         # NOTE: nodal balance is also contributed by unserved load
-        pb = 'Bbus@aBus + Pbusinj@tlv + Cl@(pds-pdu) + Csh@gsh@tlv - Cg@pg'
+        pb = 'Bbus@aBus + Pbusinj@tlv + Cl@(pds-pdu) + Csh@gsh@tlv - Cg@pg == 0'
         self.pb.e_str = pb
 
         # --- objective ---

--- a/ams/routines/uc2.py
+++ b/ams/routines/uc2.py
@@ -43,7 +43,7 @@ class UC2(PTDFMPBase, UC):
         super().__init__(system, config, **kwargs)
 
         # rewrite power balance to include unserved load `pdu`
-        self.pb.e_str = "cp.sum(pg, axis=0) - cp.sum(pds - pdu, axis=0)"
+        self.pb.e_str = "cp.sum(pg, axis=0) - cp.sum(pds - pdu, axis=0) == 0"
 
         # rewrite Expression plf to include unserved load `pdu`
         self.plf.e_str = "PTDF @ (Cg@pg - Cl@(pds - pdu) - Csh@gsh@tlv - Pbusinj@tlv)"

--- a/docs/source/modeling/example.rst
+++ b/docs/source/modeling/example.rst
@@ -102,20 +102,20 @@ Model Section
                               name='aBus', tex_name=r'\theta_{bus}',
                               model='Bus', src='a',)
               # --- power balance ---
-              pb = 'Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg'
+              pb = 'Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg == 0'
               self.pb = Constraint(name='pb', info='power balance',
-                                   e_str=pb, is_eq=True,)
+                                   e_str=pb,)
               # --- line flow ---
               self.plf = Var(info='Line flow',
                              unit='p.u.',
                              name='plf', tex_name=r'p_{lf}',
                              model='Line',)
               self.plflb = Constraint(info='line flow lower bound',
-                                      name='plflb', type='uq',
-                                      e_str='-Bf@aBus - Pfinj - rate_a',)
+                                      name='plflb',
+                                      e_str='-Bf@aBus - Pfinj - rate_a <= 0',)
               self.plfub = Constraint(info='line flow upper bound',
-                                      name='plfub', type='uq',
-                                      e_str='Bf@aBus + Pfinj - rate_a',)
+                                      name='plfub',
+                                      e_str='Bf@aBus + Pfinj - rate_a <= 0',)
               # --- objective ---
               obj = 'cp.sum(cp.multiply(c2, pg**2))'
               obj += '+ cp.sum(cp.multiply(c1, pg))'

--- a/docs/source/modeling/migration_cvxpy_namespace.rst
+++ b/docs/source/modeling/migration_cvxpy_namespace.rst
@@ -224,26 +224,50 @@ The ``inputs_dict``, ``services_dict``, ``tex_names``, and
 ``tex_map`` attributes on ``SymProcessor`` are unchanged — they
 still feed LaTeX rendering and downstream consumers.
 
-Constraint relational operators in ``e_str``
---------------------------------------------
+``Constraint.is_eq`` retired — embedded-operator LHS-zero ``e_str``
+-------------------------------------------------------------------
 
-A small behavior change rides with the eval-fallback unification:
-:py:class:`ams.opt.Constraint` ``e_str`` may now contain a
-relational operator directly:
+The ``is_eq`` parameter on :py:class:`ams.opt.Constraint` and
+:py:meth:`ams.routines.routine.RoutineBase.addConstrs` is removed.
+Every ``e_str`` must embed the relational operator and follow the
+LHS-zero authoring discipline — all terms on the left, ``<= 0``,
+``== 0``, or ``>= 0`` on the right:
 
 .. code-block:: python
 
-   sp.RTED.addConstrs(name='pg_cap', e_str='pg <= pmax')
+   # Before — operator implicit, polarity in is_eq flag
+   self.pglb = Constraint(name='pglb', e_str='-pg + pmine')
+   self.pb = Constraint(name='pb', e_str=pb, is_eq=True)
+   sp.RTED.addConstrs(name='cap', e_str='pg - pmax', is_eq=False)
 
-Previously ``Constraint.parse()`` appended ``' == 0'`` (or
-``' <= 0'``) unconditionally and an embedded operator would have
-been a syntax-level "double op" at evaluate time. The runtime
-now dispatches on whether the eval result is already a
-``cp.constraints.Constraint`` and skips the wrap when it is.
+   # After — operator embedded, single source of truth in e_str
+   self.pglb = Constraint(name='pglb', e_str='-pg + pmine <= 0')
+   self.pb = Constraint(name='pb', e_str=pb + ' == 0')
+   sp.RTED.addConstrs(name='cap', e_str='pg - pmax <= 0')
 
-The ``is_eq`` flag still works for the canonical ``... == 0`` /
-``... <= 0`` form — this is only an additional accepted shape, not
-a replacement.
+**Why LHS-zero rather than ``pg <= pmax``-style?** ``Constraint.v``
+returns ``optz._expr.value`` — the CVXPY-canonical LHS expression.
+With LHS-zero authoring, ``.v`` is the slack from zero (negative =
+respected, positive = violated, magnitude = by how much). Both
+authoring forms preserve the invariant since CVXPY normalizes
+``a <= b`` and ``b >= a`` to ``_expr = a - b`` internally — but
+the LHS-zero form makes the diagnostic intent explicit in the
+source text.
+
+Strict ``<`` and ``>`` are not accepted by CVXPY anywhere
+(``NotImplementedError``); only ``<=``, ``==``, ``>=`` may end an
+``e_str``.
+
+A ``Constraint`` whose ``e_str`` (or ``e_fn`` body) does not
+produce a ``cp.constraints.Constraint`` raises ``TypeError`` at
+evaluate time with a message naming the embedded-operator forms
+expected.
+
+**Custom callables.** Authors who supply their own ``e_fn`` (instead
+of ``e_str``) must now return a fully-formed
+``cp.constraints.Constraint`` — the codegen convention of returning
+a bare LHS expression and letting ``Constraint.evaluate`` apply
+``<= 0`` / ``== 0`` is gone.
 
 See also
 --------

--- a/docs/source/modeling/migration_cvxpy_namespace.rst
+++ b/docs/source/modeling/migration_cvxpy_namespace.rst
@@ -269,6 +269,12 @@ of ``e_str``) must now return a fully-formed
 a bare LHS expression and letting ``Constraint.evaluate`` apply
 ``<= 0`` / ``== 0`` is gone.
 
+**Cached pycode is auto-invalidated.** ``PYCODE_FORMAT_VERSION`` is
+bumped in lockstep with this change, so any
+``~/.ams/pycode/<routine>.py`` written by a pre-retirement AMS is
+rejected on first read and regenerated. No manual
+``ams prep --force`` needed after upgrade.
+
 See also
 --------
 

--- a/docs/source/modeling/routine.rst
+++ b/docs/source/modeling/routine.rst
@@ -26,9 +26,9 @@ A simplified code snippet for RTED is shown below as an example.
                                info='Sum Gen vars vector in shape of zone',
                                no_parse=True, sparse=True)
             ... ...
-            self.rbu = Constraint(name='rbu', is_eq=True,
+            self.rbu = Constraint(name='rbu',
                                   info='RegUp reserve balance',
-                                  e_str = 'gs @ cp.multiply(ug, pru) - dud')
+                                  e_str = 'gs @ cp.multiply(ug, pru) - dud == 0')
             ... ...
 
 Routine Parameter
@@ -134,8 +134,11 @@ Other canonical-CVXPY constructs in ``e_str``:
   ``cp.vstack(...)``, ``cp.hstack(...)``, ``cp.maximum(...)``,
   ``cp.minimum(...)``, ``cp.quad_form(...)``,
   ``cp.sum_squares(...)``, ``cp.diag(...)`` — call directly.
-* Comparisons ``... == 0`` and ``... <= 0`` define equality and inequality
-  constraints respectively (set via the ``is_eq`` flag on ``Constraint``).
+* Comparisons ``... == 0`` / ``... <= 0`` / ``... >= 0`` are
+  embedded in the ``e_str`` itself; the LHS-zero authoring
+  convention keeps ``Constraint.v`` reporting slack-from-zero
+  uniformly. See :ref:`migration_cvxpy_namespace` for the v1.2.2
+  ``is_eq`` retirement.
 * Powers use ``**`` (e.g. ``vmax**2``).
 
 .. warning::

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -12,6 +12,40 @@ v1.2
 v1.2.2 (unreleased)
 ----------------------
 
+**Migration — ``Constraint.is_eq`` retired:**
+
+The ``is_eq`` parameter on :class:`ams.opt.Constraint` and
+:meth:`ams.routines.routine.RoutineBase.addConstrs` is removed.
+Every ``Constraint`` ``e_str`` must now embed the relational
+operator in the LHS-zero form: ``'<LHS> <= 0'``, ``'<LHS> == 0'``,
+or ``'<LHS> >= 0'``. The CVXPY canonicalization of every
+inequality to ``lhs - rhs <= 0`` (regardless of ``<=`` vs ``>=``
+direction) means ``Constraint.v`` keeps reporting slack-from-zero
+uniformly.
+
+Update any user routines or runtime customizations:
+
+.. code-block:: python
+
+   # Before
+   self.pglb = Constraint(name='pglb', e_str='-pg + pmine')
+   self.pb = Constraint(name='pb', e_str=pb, is_eq=True)
+   sp.RTED.addConstrs(name='cap', e_str='pg - pmax', is_eq=False)
+
+   # After
+   self.pglb = Constraint(name='pglb', e_str='-pg + pmine <= 0')
+   self.pb = Constraint(name='pb', e_str=pb + ' == 0')
+   sp.RTED.addConstrs(name='cap', e_str='pg - pmax <= 0')
+
+A ``Constraint`` whose ``e_str`` (or ``e_fn`` body) does not
+produce a ``cp.constraints.Constraint`` now raises ``TypeError``
+at evaluate time with a message naming the embedded-operator
+forms expected. The codegen and eval-fallback paths share this
+behavior.
+
+See :ref:`migration_cvxpy_namespace` for the full rationale and
+worked examples.
+
 **Migration — ``e_str`` authoring contract:**
 
 Routine ``e_str`` strings (built-in routines and any user customization

--- a/examples/demonstration/demo_debug.ipynb
+++ b/examples/demonstration/demo_debug.ipynb
@@ -14,7 +14,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:36.127831Z",
+     "iopub.status.busy": "2026-05-02T08:23:36.127295Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.212098Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.211771Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import ams"
@@ -23,7 +30,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.213398Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.213284Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.215466Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.215206Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ams.config_logger(stream_level=20)"
@@ -39,16 +53,62 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.216695Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.216620Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.325590Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.325324Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Parsing input file \"/Users/jinningwang/work/ams/ams/cases/matpower/case14.m\"...\n",
-      "Input file parsed in 0.0070 seconds.\n",
-      "Zero line rates detacted in rate_a, rate_b, rate_c, adjusted to 999.\n",
-      "System set up in 0.0034 seconds.\n"
+      "Working directory: \"/Users/jinningwang/work/ams/examples/demonstration\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "> Loaded config from file \"/Users/jinningwang/.ams/ams.rc\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsing input file \"/Users/jinningwang/work/ams/ams/cases/matpower/case14.m\"...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "CASE14    Power flow data for IEEE 14 bus test case.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Input file parsed in 0.0033 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Zero Line parameters detected, adjusted to default values: rate_a, rate_b, rate_c.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "System set up in 0.0017 seconds.\n"
      ]
     }
    ],
@@ -60,18 +120,76 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.326675Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.326577Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.377477Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.377254Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Building system matrices\n",
-      "Parsing OModel for <DCOPF>\n",
-      "Evaluating OModel for <DCOPF>\n",
-      "Finalizing OModel for <DCOPF>\n",
-      "<DCOPF> initialized in 0.0144 seconds.\n",
-      "<DCOPF> solved as optimal in 0.0160 seconds, converged in 11 iterations with CLARABEL.\n"
+      "Entering data check for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " -> Data check passed\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Building system matrices\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> formulation: codegen=15/15\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsing OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Finalizing OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> initialized in 0.0403 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> solved as optimal in 0.0070 seconds, converged in 11 iterations with CLARABEL.\n"
      ]
     },
     {
@@ -92,7 +210,14 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.378559Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.378468Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.380394Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.380191Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -119,7 +244,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.381411Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.381343Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.383265Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.383052Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -146,7 +278,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.384372Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.384281Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.386504Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.386277Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -173,7 +312,14 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.387611Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.387521Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.391506Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.391287Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -207,7 +353,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.392512Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.392430Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.394501Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.394312Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -241,16 +394,62 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.395426Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.395357Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.404858Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.404639Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Disabled constraints: pglb, pgub\n",
-      "Finalizing OModel for <DCOPF>\n",
-      "<DCOPF> initialized in 0.0019 seconds.\n",
-      "<DCOPF> solved as optimal in 0.0167 seconds, converged in 9 iterations with CLARABEL.\n"
+      "Entering data check for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " -> Data check passed\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Disabled constraints: pglb, pgub\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> formulation: codegen=15/15\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Finalizing OModel for <DCOPF>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> initialized in 0.0022 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<DCOPF> solved as optimal in 0.0048 seconds, converged in 9 iterations with CLARABEL.\n"
      ]
     },
     {
@@ -271,7 +470,14 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.405993Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.405921Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.407873Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.407673Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -292,13 +498,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since all the inequality constraints are written in the form of $Ax -b \\leq 0$, we can check the violated constraints by finding the those with positive `Constraint.e`."
+    "## Why `Constraint.e` is always slack-from-zero\n",
+    "\n",
+    "Every routine constraint is authored in the **LHS-zero form** —\n",
+    "all terms on the left, `<= 0` / `== 0` / `>= 0` on the right\n",
+    "(post-v1.2.2; see the `is_eq` retirement migration). CVXPY then\n",
+    "canonicalizes every inequality internally to `lhs - rhs <= 0`\n",
+    "**regardless of operator direction**:\n",
+    "\n",
+    "```python\n",
+    "import cvxpy as cp\n",
+    "a = cp.Variable(3, name='a'); b = cp.Variable(3, name='b')\n",
+    "(a <= b)._expr   # → a - b\n",
+    "(b >= a)._expr   # → a - b   (same! __ge__ swaps operands)\n",
+    "```\n",
+    "\n",
+    "`Constraint.e` (and `Constraint.v`) returns this canonical\n",
+    "`lhs - rhs` value — i.e. the slack from zero. So:\n",
+    "\n",
+    "* **negative** = constraint is respected, with that much margin\n",
+    "* **positive** = constraint is violated by that amount\n",
+    "* **zero** = constraint is exactly tight\n",
+    "\n",
+    "The diagnostic is uniform across every constraint in every\n",
+    "routine. For an infeasible problem, scanning each constraint's\n",
+    "`.e` for positive entries pinpoints exactly which constraints\n",
+    "fail and by how much. CVXPY rejects strict `<` / `>` (raises\n",
+    "`NotImplementedError`), so only `<=`, `>=`, and `==` reach the\n",
+    "solver — the canonicalization is total."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.408884Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.408821Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.411148Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.410946Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -318,7 +558,14 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-02T08:23:37.412106Z",
+     "iopub.status.busy": "2026-05-02T08:23:37.412037Z",
+     "iopub.status.idle": "2026-05-02T08:23:37.413937Z",
+     "shell.execute_reply": "2026-05-02T08:23:37.413769Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -352,7 +599,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/examples/ex8.ipynb
+++ b/examples/ex8.ipynb
@@ -49,10 +49,10 @@
    "id": "36eb23ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:12.724122Z",
-     "iopub.status.busy": "2026-05-02T06:30:12.723210Z",
-     "iopub.status.idle": "2026-05-02T06:30:13.838070Z",
-     "shell.execute_reply": "2026-05-02T06:30:13.837744Z"
+     "iopub.execute_input": "2026-05-02T08:23:33.168042Z",
+     "iopub.status.busy": "2026-05-02T08:23:33.167572Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.374362Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.374080Z"
     }
    },
    "outputs": [],
@@ -77,10 +77,10 @@
    "id": "a803c68e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:13.839727Z",
-     "iopub.status.busy": "2026-05-02T06:30:13.839579Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.096480Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.096219Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.375772Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.375649Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.649767Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.649483Z"
     }
    },
    "outputs": [
@@ -102,7 +102,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Input file parsed in 0.0992 seconds.\n"
+      "Input file parsed in 0.1174 seconds.\n"
      ]
     },
     {
@@ -123,7 +123,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "System set up in 0.0021 seconds.\n"
+      "System set up in 0.0019 seconds.\n"
      ]
     },
     {
@@ -179,14 +179,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> initialized in 0.0429 seconds.\n"
+      "<DCOPF> initialized in 0.0416 seconds.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> solved as optimal in 0.0069 seconds, converged in 9 iterations with CLARABEL.\n"
+      "<DCOPF> solved as optimal in 0.0073 seconds, converged in 9 iterations with CLARABEL.\n"
      ]
     },
     {
@@ -212,10 +212,10 @@
    "id": "a7853b7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.097858Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.097746Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.099554Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.099323Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.651184Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.651062Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.653027Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.652805Z"
     }
    },
    "outputs": [
@@ -239,10 +239,10 @@
    "id": "52ee8895",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.100642Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.100574Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.102291Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.102040Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.654185Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.654090Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.656012Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.655735Z"
     }
    },
    "outputs": [
@@ -256,14 +256,14 @@
       "  expr      plf    codegen  Bf@aBus + Pfinj\n",
       "  expr      pmaxe  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmax)\n",
       "  expr      pmine  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmin)\n",
-      "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg\n",
-      "  constr    sba    codegen  isb@aBus\n",
-      "  constr    pglb   codegen  -pg + pmine\n",
-      "  constr    pgub   codegen  pg - pmaxe\n",
-      "  constr    plflb  codegen  -plf - cp.multiply(ul, rate_a)\n",
-      "  constr    plfub  codegen  plf - cp.multiply(ul, rate_a)\n",
-      "  constr    alflb  codegen  -CftT@aBus + amin\n",
-      "  constr    alfub  codegen  CftT@aBus - amax\n",
+      "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg == 0\n",
+      "  constr    sba    codegen  isb@aBus == 0\n",
+      "  constr    pglb   codegen  -pg + pmine <= 0\n",
+      "  constr    pgub   codegen  pg - pmaxe <= 0\n",
+      "  constr    plflb  codegen  -plf - cp.multiply(ul, rate_a) <= 0\n",
+      "  constr    plfub  codegen  plf - cp.multiply(ul, rate_a) <= 0\n",
+      "  constr    alflb  codegen  -CftT@aBus + amin <= 0\n",
+      "  constr    alfub  codegen  CftT@aBus - amax <= 0\n",
       "  exprcalc  pi     codegen  pb.dual_variables[0]\n",
       "  exprcalc  mu1    codegen  plflb.dual_variables[0]\n",
       "  exprcalc  mu2    codegen  plfub.dual_variables[0]\n",
@@ -304,10 +304,10 @@
    "id": "b4f49c0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.103557Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.103483Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.242394Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.242163Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.657492Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.657373Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.799167Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.798899Z"
     }
    },
    "outputs": [
@@ -329,7 +329,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Input file parsed in 0.0791 seconds.\n"
+      "Input file parsed in 0.0797 seconds.\n"
      ]
     },
     {
@@ -350,7 +350,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "System set up in 0.0020 seconds.\n"
+      "System set up in 0.0019 seconds.\n"
      ]
     },
     {
@@ -406,7 +406,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> initialized in 0.0055 seconds.\n"
+      "<DCOPF> initialized in 0.0057 seconds.\n"
      ]
     },
     {
@@ -455,14 +455,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> initialized in 0.0054 seconds.\n"
+      "<DCOPF> initialized in 0.0057 seconds.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> solved as optimal in 0.0059 seconds, converged in 12 iterations with CLARABEL.\n"
+      "<DCOPF> solved as optimal in 0.0064 seconds, converged in 12 iterations with CLARABEL.\n"
      ]
     },
     {
@@ -497,10 +497,14 @@
     "sp2.DCOPF.addService(name='te', tex_name='t_e', info='emission cap', value=1.0)\n",
     "sp2.DCOPF.addVars(name='eg', tex_name='e_g', info='gen emission',\n",
     "                   unit='t', model='StaticGen')\n",
+    "# is_eq retired in v1.2.2 — embed the relational operator in e_str\n",
+    "# directly. LHS-zero discipline keeps `.v` reporting slack-from-zero\n",
+    "# (negative = respected, positive = violated) regardless of `<=`/`>=`\n",
+    "# direction (CVXPY canonicalizes both to `lhs - rhs <= 0` internally).\n",
     "sp2.DCOPF.addConstrs(name='egb', info='emission balance',\n",
-    "                      e_str='eg - cp.multiply(ke, pg)', is_eq=True)\n",
+    "                      e_str='eg - cp.multiply(ke, pg) == 0')\n",
     "sp2.DCOPF.addConstrs(name='eub', info='emission cap',\n",
-    "                      e_str='cp.sum(eg) - te', is_eq=False)\n",
+    "                      e_str='cp.sum(eg) - te <= 0')\n",
     "sp2.DCOPF.obj.e_str += '+ cp.sum(cp.multiply(ce, pg))'\n",
     "\n",
     "sp2.DCOPF.run(solver='CLARABEL')"
@@ -512,10 +516,10 @@
    "id": "90ef5387",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.243771Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.243662Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.245569Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.245353Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.800510Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.800321Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.802403Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.802203Z"
     }
    },
    "outputs": [
@@ -539,10 +543,10 @@
    "id": "2665d6ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.246813Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.246711Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.248468Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.248259Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.803559Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.803456Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.805266Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.805042Z"
     }
    },
    "outputs": [
@@ -556,16 +560,16 @@
       "  expr      plf    codegen  Bf@aBus + Pfinj\n",
       "  expr      pmaxe  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmax)\n",
       "  expr      pmine  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmin)\n",
-      "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg\n",
-      "  constr    sba    codegen  isb@aBus\n",
-      "  constr    pglb   codegen  -pg + pmine\n",
-      "  constr    pgub   codegen  pg - pmaxe\n",
-      "  constr    plflb  codegen  -plf - cp.multiply(ul, rate_a)\n",
-      "  constr    plfub  codegen  plf - cp.multiply(ul, rate_a)\n",
-      "  constr    alflb  codegen  -CftT@aBus + amin\n",
-      "  constr    alfub  codegen  CftT@aBus - amax\n",
-      "  constr    egb    eval     eg - cp.multiply(ke, pg)\n",
-      "  constr    eub    eval     cp.sum(eg) - te\n",
+      "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg == 0\n",
+      "  constr    sba    codegen  isb@aBus == 0\n",
+      "  constr    pglb   codegen  -pg + pmine <= 0\n",
+      "  constr    pgub   codegen  pg - pmaxe <= 0\n",
+      "  constr    plflb  codegen  -plf - cp.multiply(ul, rate_a) <= 0\n",
+      "  constr    plfub  codegen  plf - cp.multiply(ul, rate_a) <= 0\n",
+      "  constr    alflb  codegen  -CftT@aBus + amin <= 0\n",
+      "  constr    alfub  codegen  CftT@aBus - amax <= 0\n",
+      "  constr    egb    eval     eg - cp.multiply(ke, pg) == 0\n",
+      "  constr    eub    eval     cp.sum(eg) - te <= 0\n",
       "  exprcalc  pi     codegen  pb.dual_variables[0]\n",
       "  exprcalc  mu1    codegen  plflb.dual_variables[0]\n",
       "  exprcalc  mu2    codegen  plfub.dual_variables[0]\n",
@@ -610,10 +614,10 @@
    "id": "080b56ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.249525Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.249457Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.331101Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.330893Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.806553Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.806445Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.888668Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.888421Z"
     }
    },
    "outputs": [
@@ -635,7 +639,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Input file parsed in 0.0318 seconds.\n"
+      "Input file parsed in 0.0315 seconds.\n"
      ]
     },
     {
@@ -656,7 +660,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "System set up in 0.0018 seconds.\n"
+      "System set up in 0.0019 seconds.\n"
      ]
     },
     {
@@ -712,14 +716,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> initialized in 0.0053 seconds.\n"
+      "<DCOPF> initialized in 0.0052 seconds.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<DCOPF> solved as optimal in 0.0049 seconds, converged in 9 iterations with CLARABEL.\n"
+      "<DCOPF> solved as optimal in 0.0050 seconds, converged in 9 iterations with CLARABEL.\n"
      ]
     },
     {
@@ -745,10 +749,10 @@
    "id": "0ff00f4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.332189Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.332114Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.333920Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.333742Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.889886Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.889796Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.891671Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.891468Z"
     }
    },
    "outputs": [
@@ -772,10 +776,10 @@
    "id": "200d1fd0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.334808Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.334739Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.336459Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.336235Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.892759Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.892677Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.894532Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.894322Z"
     }
    },
    "outputs": [
@@ -789,14 +793,14 @@
       "  expr      plf    codegen  Bf@aBus + Pfinj\n",
       "  expr      pmaxe  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmax)\n",
       "  expr      pmine  codegen  cp.multiply(nctrle, pg0) + cp.multiply(ctrle, pmin)\n",
-      "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg\n",
-      "  constr    sba    codegen  isb@aBus\n",
-      "  constr    pglb   codegen  -pg + pmine\n",
-      "  constr    pgub   codegen  pg - pmaxe\n",
-      "  constr    plflb  codegen  -plf - cp.multiply(ul, rate_a)\n",
-      "  constr    plfub  codegen  plf - cp.multiply(ul, rate_a)\n",
-      "  constr    alflb  codegen  -CftT@aBus + amin\n",
-      "  constr    alfub  codegen  CftT@aBus - amax\n",
+      "  constr    pb     codegen  Bbus@aBus + Pbusinj + Cl@pd + Csh@gsh - Cg@pg == 0\n",
+      "  constr    sba    codegen  isb@aBus == 0\n",
+      "  constr    pglb   codegen  -pg + pmine <= 0\n",
+      "  constr    pgub   codegen  pg - pmaxe <= 0\n",
+      "  constr    plflb  codegen  -plf - cp.multiply(ul, rate_a) <= 0\n",
+      "  constr    plfub  codegen  plf - cp.multiply(ul, rate_a) <= 0\n",
+      "  constr    alflb  codegen  -CftT@aBus + amin <= 0\n",
+      "  constr    alfub  codegen  CftT@aBus - amax <= 0\n",
       "  exprcalc  pi     codegen  pb.dual_variables[0]\n",
       "  exprcalc  mu1    codegen  plflb.dual_variables[0]\n",
       "  exprcalc  mu2    codegen  plfub.dual_variables[0]\n",
@@ -822,10 +826,10 @@
    "id": "e56c6dfb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.337479Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.337415Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.339635Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.339416Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.895522Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.895461Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.897677Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.897472Z"
     }
    },
    "outputs": [
@@ -874,10 +878,10 @@
    "id": "c768505d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.340712Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.340637Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.342509Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.342324Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.898684Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.898610Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.900453Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.900252Z"
     }
    },
    "outputs": [
@@ -902,10 +906,10 @@
    "id": "d329d0f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.343448Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.343379Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.345155Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.344959Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.901481Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.901417Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.903259Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.903028Z"
     }
    },
    "outputs": [
@@ -930,10 +934,10 @@
    "id": "4ed99879",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T06:30:14.346203Z",
-     "iopub.status.busy": "2026-05-02T06:30:14.346115Z",
-     "iopub.status.idle": "2026-05-02T06:30:14.347864Z",
-     "shell.execute_reply": "2026-05-02T06:30:14.347690Z"
+     "iopub.execute_input": "2026-05-02T08:23:34.904390Z",
+     "iopub.status.busy": "2026-05-02T08:23:34.904306Z",
+     "iopub.status.idle": "2026-05-02T08:23:34.906277Z",
+     "shell.execute_reply": "2026-05-02T08:23:34.906072Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary

Closes the cvxpy-namespace passthrough follow-on (`projects/is_eq_retirement/`).

Drops the `is_eq` parameter from `Constraint.__init__` and `RoutineBase.addConstrs`. Every Constraint now embeds the relational operator directly in `e_str` — `'<LHS> <= 0'`, `'<LHS> == 0'`, or `'<LHS> >= 0'` — preserving the LHS-zero authoring discipline so `Constraint.v` keeps reporting **slack-from-zero** uniformly.

**Why this works:** CVXPY canonicalizes every inequality to `_expr = lhs - rhs` regardless of `<=` / `>=` direction (verified — `(b >= a)._expr` is `a - b`, not `b - a`). The diagnostic invariant rides on `_expr`; both authoring forms preserve it. With `is_eq` gone, the operator lives in exactly one place (the `e_str` text), eliminating the silent-override footgun (`e_str='pg <= pmax', is_eq=True` previously ignored `is_eq`).

## Architectural decision: single source of truth in `e_str`

`documenter.py:360` previously branched on `p.is_eq` to render `= 0` vs `\leq 0`. The instinct was to stash a derived `_is_eq` from parsing `e_str` (option b in research) — but that re-creates the parallel-truth channel as a private attribute. Chose option (c): three new `tex_map` / `_TEX_TEMPLATES` rules (`<= -> \leq`, `>= -> \geq`, `== -> =`) translate the embedded operator into LaTeX. Documenter loop collapses to one `_tex_pre()` call. Single source of truth.

## What changed

**Core:**
- `Constraint.__init__` drops `is_eq` parameter and `self.is_eq` attribute.
- `Constraint.evaluate()` requires `cp.constraints.Constraint` result; raises `TypeError` with a clear "embed `<= 0` / `== 0` / `>= 0`" message otherwise.
- `RoutineBase.addConstrs` drops `is_eq` parameter; refreshed docstring + example.
- `eval_e_str_numeric` strips the trailing operator before numpy eval (else short-circuits to a bool array).
- `OptzBase.e` reorders to prefer the e_str-driven numeric path whenever `e_str` is available (preserved post-codegen wiring) — uniform for codegen and eval-fallback paths.
- `documenter.py:360-364` simplified — branching deleted.
- Three relational tex rules added to both `SymProcessor.tex_map` (`ams/core/symprocessor.py`) and `_TEX_TEMPLATES` (`ams/prep/generator.py`) — they're documented to "both must agree".

**Routine sites:** ~73 Constraint constructors across 12 files (`dcopf.py`, `dcopf2.py`, `dcpf.py`, `dopf.py`, `ed.py`, `ed2.py`, `pflow.py`, `pypower.py`, `routine.py`, `rted.py`, `uc.py`, `uc2.py`). Mechanical migration via `icebar/migrate_is_eq.py` (gitignored), plus hand-pass for ~16 deferred-assignment sites where `is_eq` lived in a sibling declaration.

**Docs:**
- `docs/source/release-notes.rst` — new v1.2.2 migration section.
- `docs/source/modeling/migration_cvxpy_namespace.rst` — new "is_eq retirement" section with rationale, before/after examples, custom-callable note.
- `docs/source/modeling/routine.rst` — refresh `is_eq` mention, sample Constraint snippet.
- `docs/source/modeling/example.rst` — DCOPF example updated.

**Notebooks:**
- `examples/ex8.ipynb` — `addConstrs` calls migrated, comment explaining the move.
- `examples/demonstration/demo_debug.ipynb` — new explainer cell on CVXPY's canonicalization (per maintainer's 2026-05-02 question that motivated this PR), making the `.e` slack diagnostic feel less mysterious.

## Test plan

- [x] `pytest tests/`: 348 passed.
- [x] `flake8 ams/ --max-line-length=120 --exclude=ams/thirdparty`: clean.
- [x] `make distclean html SPHINXOPTS='-W --keep-going -j auto'`: clean.
- [x] `jupyter nbconvert --execute --inplace ex8.ipynb demo_debug.ipynb`: re-executed cleanly with refreshed outputs.
- [x] Generated pycode tex strings render correctly: `pglb -> '... \\leq 0'`, `pb -> '... = 0'`.
- [ ] Reviewer agent — independent reviewer for accuracy of routine-site migrations + correctness of `.e` codegen-path reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)