### PR TITLE
opt: tighten eval-fallback with LHS-zero check + DCP visibility

### DIFF
--- a/ams/opt/_runtime_eval.py
+++ b/ams/opt/_runtime_eval.py
@@ -157,8 +157,11 @@ def assert_constraint_lhs_zero(item, e_str):
             f"with `<= 0`, `== 0`, or `>= 0` (LHS-zero authoring shape). "
             f"Got: {e_str!r}. Move every term to the LHS — "
             f"e.g. `pg - pmax <= 0` instead of `pg <= pmax`. "
-            f"Without the trailing-zero shape, `OptzBase.e` returns a "
-            f"numpy bool array instead of the LHS slack."
+            f"The trailing zero is matched literally (`0`, not `0.0` "
+            f"or `(0)`) so the same regex strips it cleanly inside "
+            f":func:`eval_e_str_numeric`. Without the trailing-zero "
+            f"shape, `OptzBase.e` returns a numpy bool array instead "
+            f"of the LHS slack."
         )
 
 

--- a/ams/opt/_runtime_eval.py
+++ b/ams/opt/_runtime_eval.py
@@ -88,12 +88,18 @@ def eval_e_str(item, e_str):
         'cp': cp, 'np': np, 'sps': sps,
         'r': RoutineNS(rtn), 'self': item,
     }
-    # Trust boundary: e_str is repo-authored in ams/routines/ or
-    # comes from trusted downstream code (notebook authors, mixins).
-    # Same boundary as the codegen-emitted pycode — both run user-
-    # accessible source through Python. No untrusted-input ingestion.
+    # Trust boundary: e_str is Python source eval'd in a curated
+    # namespace (cp/np/sps + the routine's symbol proxy). Authors come
+    # from three places — repo source under ``ams/routines/``, mixin
+    # overrides, and downstream user code (notebook ``addConstrs``,
+    # ``item.e_str = ...`` assignments after cvxpy-namespace passthrough
+    # opened the full ``cp.*`` surface). All three ride the same path;
+    # treat them with the same trust as the codegen-emitted pycode —
+    # both run user-accessible source through Python. No untrusted-
+    # input ingestion contract here, so authors are responsible for
+    # what their ``e_str`` evaluates to.
     try:
-        return eval(code, {}, local_vars)  # nosec B307
+        result = eval(code, {}, local_vars)  # nosec B307
     except Exception as exc:
         raise Exception(
             f"Error evaluating {item.class_name} <{item.name}> via e_str.\n"
@@ -101,9 +107,59 @@ def eval_e_str(item, e_str):
             f"  rewritten: {code}\n"
             f"  error: {exc}"
         ) from exc
+    # Per-item DCP visibility for the eval-fallback path. The codegen
+    # path skips eval entirely, so non-DCP drift in built-in routines
+    # surfaces at the problem level via ``OModel._log_dpp_diagnostic``.
+    # User customizations / addConstrs / mixin overrides are the only
+    # things that hit eval_e_str at runtime, and they're exactly where
+    # silent DCP drift is most likely (e.g. ``cp.multiply(pg, pg)``
+    # instead of ``cp.square(pg)``). Log a warning here so the
+    # author sees the offending item by name, instead of a generic
+    # solve-time CVXPY DCPError that points at the whole problem.
+    is_dcp = getattr(result, 'is_dcp', None)
+    if callable(is_dcp):
+        try:
+            ok = is_dcp()
+        except Exception:  # noqa: BLE001 — DCP introspection must not block evaluation
+            ok = True
+        if not ok:
+            logger.warning(
+                f"{item.class_name} <{item.name}> e_str produced a "
+                f"non-DCP CVXPY object — solver will likely raise.\n"
+                f"  e_str: {e_str}"
+            )
+    return result
 
 
 _TRAILING_OP_RE = re.compile(r'\s*(==|<=|>=)\s*0\s*$')
+
+
+def assert_constraint_lhs_zero(item, e_str):
+    """Validate constraint ``e_str`` ends with ``<= 0`` / ``== 0`` / ``>= 0``.
+
+    The LHS-zero shape is the only authoring shape after the
+    ``is_eq`` retirement (PR #249) — every term goes on the LHS so
+    :pyattr:`OptzBase.e` can recover the slack-from-zero LHS by
+    stripping the trailing operator. Without the convention,
+    ``pg <= pmax`` survives ``Constraint.evaluate`` (CVXPY accepts
+    it), but :pyattr:`OptzBase.e` returns a numpy bool array
+    instead of the LHS slack — silently wrong post-solve diagnostics.
+
+    Raises
+    ------
+    ValueError
+        If ``e_str`` does not end with the required relational
+        operator + ``0`` form.
+    """
+    if _TRAILING_OP_RE.search(e_str) is None:
+        raise ValueError(
+            f"Constraint <{getattr(item, 'name', '?')}>: e_str must end "
+            f"with `<= 0`, `== 0`, or `>= 0` (LHS-zero authoring shape). "
+            f"Got: {e_str!r}. Move every term to the LHS — "
+            f"e.g. `pg - pmax <= 0` instead of `pg <= pmax`. "
+            f"Without the trailing-zero shape, `OptzBase.e` returns a "
+            f"numpy bool array instead of the LHS slack."
+        )
 
 
 def eval_e_str_numeric(item, e_str):

--- a/ams/opt/constraint.py
+++ b/ams/opt/constraint.py
@@ -15,7 +15,7 @@ from ams.shared import _prefix, _max_length
 from ams.core.routine_ns import RoutineNS
 from ams.opt import OptzBase, ensure_symbols, ensure_mats_and_parsed
 from ams.opt.optzbase import _EFormDescriptor
-from ams.opt._runtime_eval import eval_e_str
+from ams.opt._runtime_eval import eval_e_str, assert_constraint_lhs_zero
 
 logger = logging.getLogger(__name__)
 
@@ -94,14 +94,21 @@ class Constraint(OptzBase):
         """
         Parse the constraint.
 
-        Codegen-wired ``e_fn`` items have nothing to parse. For the
-        legacy ``e_str`` path, store the source verbatim — symbol
-        rewriting + eval happen together in
+        Validates the LHS-zero authoring shape on every constraint
+        carrying an ``e_str`` (covers both the codegen path —
+        ``e_str`` is preserved on the item — and the eval-fallback
+        path). See :func:`assert_constraint_lhs_zero` for why.
+
+        Codegen-wired ``e_fn`` items then short-circuit; nothing else
+        to parse here. For the legacy ``e_str`` path, store the
+        source verbatim — symbol rewriting + eval happen together in
         :func:`ams.opt._runtime_eval.eval_e_str` at evaluate time.
         ``self.code`` is preserved (as the unrewritten source) so
         :pyattr:`OptzBase.e` and :meth:`Routine.formulation_summary`
         still have something to read.
         """
+        if self.e_str is not None:
+            assert_constraint_lhs_zero(self, self.e_str)
         if self.e_fn is not None:
             return True
         self.code = self.e_str

--- a/ams/prep/generator.py
+++ b/ams/prep/generator.py
@@ -48,11 +48,45 @@ PYCODE_FORMAT_VERSION = 3
 # is the user's symbol, not ``cp.sum``. Reject the collision at
 # codegen / generate_symbols time so the trap surfaces at routine
 # definition, not as silent nonsense at solve time.
-RESERVED_CVXPY_ATOM_NAMES = frozenset({
+#
+# Static fallback: the closed set we know mattered when the guard
+# shipped (PR #244-#248, cvxpy-namespace passthrough). The runtime
+# set below is unioned with this — never narrower — so a CVXPY API
+# shape change (atoms moved/removed) can shrink derivation but
+# can't shrink the guarded set.
+_STATIC_RESERVED_CVXPY_ATOM_NAMES = frozenset({
     'sum', 'multiply', 'vstack', 'hstack', 'power', 'norm', 'pos', 'neg',
     'square', 'quad_form', 'sum_squares', 'diag', 'maximum', 'minimum',
     'abs', 'exp', 'log', 'sqrt', 'inv_pos',
 })
+
+
+def _derive_reserved_cvxpy_atom_names():
+    """Discover CVXPY atom-callable names exposed at the ``cp.`` top.
+
+    Walks ``cvxpy.atoms`` (the atoms package) and keeps each public
+    name that's also exposed as a callable on the top-level ``cvxpy``
+    namespace. The result tracks whatever atoms the installed CVXPY
+    version ships, so an atom added in a future release is guarded
+    automatically (the static fallback was a snapshot — this isn't).
+    Always unioned with :data:`_STATIC_RESERVED_CVXPY_ATOM_NAMES`,
+    so it's a strict superset.
+    """
+    derived = set()
+    try:
+        atoms_mod = cp.atoms
+    except AttributeError:
+        return _STATIC_RESERVED_CVXPY_ATOM_NAMES
+    for name in dir(atoms_mod):
+        if name.startswith('_'):
+            continue
+        attr = getattr(cp, name, None)
+        if attr is not None and callable(attr):
+            derived.add(name)
+    return frozenset(derived | _STATIC_RESERVED_CVXPY_ATOM_NAMES)
+
+
+RESERVED_CVXPY_ATOM_NAMES = _derive_reserved_cvxpy_atom_names()
 
 
 def _check_reserved_collisions(routine, names) -> None:

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -9,6 +9,29 @@ The APIs before v3.0.0 are in beta and may change without prior notice.
 v1.2
 ==========
 
+v1.2.3 (unreleased)
+----------------------
+
+**Tightening the eval-fallback path:**
+
+- :class:`ams.opt.Constraint` now validates at parse time that
+  ``e_str`` ends with the LHS-zero shape (``<= 0`` / ``== 0`` /
+  ``>= 0``). Authoring ``pg <= pmax`` instead of
+  ``pg - pmax <= 0`` previously solved correctly but produced a
+  silently-wrong :pyattr:`OptzBase.e` (numpy bool array instead of
+  the LHS slack); the new :func:`ams.opt._runtime_eval.assert_constraint_lhs_zero`
+  guard surfaces the mismatch immediately with an actionable error.
+- :func:`ams.opt._runtime_eval.eval_e_str` now logs a per-item
+  ``WARNING`` when an eval-fallback constraint/objective/expression
+  yields a non-DCP CVXPY object (e.g. ``cp.multiply(pg, pg)`` instead
+  of ``cp.square(pg)``). The codegen path is unaffected; this
+  closes the visibility gap on user customizations and ``addConstrs``
+  added by the cvxpy-namespace passthrough.
+- :data:`ams.prep.generator.RESERVED_CVXPY_ATOM_NAMES` is now
+  derived at import time from ``cvxpy.atoms`` (still a strict
+  superset of the static fallback). New atoms in future CVXPY
+  releases are guarded automatically.
+
 v1.2.2 (unreleased)
 ----------------------
 

--- a/tests/opt/test_runtime_eval.py
+++ b/tests/opt/test_runtime_eval.py
@@ -20,12 +20,7 @@ import pytest
 
 import cvxpy as cp
 
-import ams
-from ams.opt import Constraint
-from ams.opt._runtime_eval import (
-    assert_constraint_lhs_zero,
-    eval_e_str,
-)
+from ams.opt._runtime_eval import assert_constraint_lhs_zero
 from ams.prep.generator import (
     RESERVED_CVXPY_ATOM_NAMES,
     _STATIC_RESERVED_CVXPY_ATOM_NAMES,

--- a/tests/opt/test_runtime_eval.py
+++ b/tests/opt/test_runtime_eval.py
@@ -1,0 +1,176 @@
+"""
+Tests for the eval-fallback safety net in :mod:`ams.opt._runtime_eval`
+plus the dynamic reserved-name guard in :mod:`ams.prep.generator`.
+
+Covers two PRs' worth of tightening that landed after the
+cvxpy-namespace passthrough and ``is_eq`` retirement:
+
+- L5 — :func:`assert_constraint_lhs_zero` rejects constraint
+  ``e_str`` that doesn't end with ``<= 0`` / ``== 0`` / ``>= 0``.
+- M4a — :func:`eval_e_str` logs a per-item warning when the
+  evaluated CVXPY object reports ``is_dcp() is False``.
+- M4b — :data:`RESERVED_CVXPY_ATOM_NAMES` is derived from
+  ``cvxpy.atoms`` at import time and is a strict superset of the
+  static fallback.
+"""
+import logging
+import unittest
+
+import pytest
+
+import cvxpy as cp
+
+import ams
+from ams.opt import Constraint
+from ams.opt._runtime_eval import (
+    assert_constraint_lhs_zero,
+    eval_e_str,
+)
+from ams.prep.generator import (
+    RESERVED_CVXPY_ATOM_NAMES,
+    _STATIC_RESERVED_CVXPY_ATOM_NAMES,
+)
+
+
+class TestAssertConstraintLhsZero(unittest.TestCase):
+    """Pure-function tests on the LHS-zero validator."""
+
+    def _stub(self, name='c'):
+        # Minimal stub — validator only reads ``.name`` for the error message.
+        class _Item:
+            pass
+        item = _Item()
+        item.name = name
+        return item
+
+    def test_accepts_le_zero(self):
+        assert_constraint_lhs_zero(self._stub(), 'pg - pmax <= 0')
+
+    def test_accepts_eq_zero(self):
+        assert_constraint_lhs_zero(self._stub(), 'cp.sum(pg) - cp.sum(pd) == 0')
+
+    def test_accepts_ge_zero(self):
+        assert_constraint_lhs_zero(self._stub(), 'pg - pmin >= 0')
+
+    def test_accepts_trailing_whitespace(self):
+        # The regex tolerates whitespace around the op and the zero.
+        assert_constraint_lhs_zero(self._stub(), 'pg - pmax  <=  0   ')
+
+    def test_rejects_missing_zero(self):
+        with self.assertRaisesRegex(ValueError, 'LHS-zero authoring shape'):
+            assert_constraint_lhs_zero(self._stub('rru'), 'pg <= pmax')
+
+    def test_rejects_eq_to_nonzero(self):
+        with self.assertRaisesRegex(ValueError, 'LHS-zero'):
+            assert_constraint_lhs_zero(self._stub(), 'cp.sum(pg) == cp.sum(pd)')
+
+    def test_rejects_no_operator(self):
+        with self.assertRaisesRegex(ValueError, 'LHS-zero'):
+            assert_constraint_lhs_zero(self._stub(), 'pg - pmax')
+
+    def test_error_quotes_offending_e_str(self):
+        with self.assertRaises(ValueError) as ctx:
+            assert_constraint_lhs_zero(self._stub('foo'), 'pg <= pmax')
+        msg = str(ctx.exception)
+        self.assertIn('foo', msg)
+        self.assertIn("'pg <= pmax'", msg)
+
+
+class TestConstraintParseRejectsBadEStr(unittest.TestCase):
+    """End-to-end: a routine constraint authored without LHS-zero
+    raises during parse (which auto-prep runs at ``om.init`` time)."""
+
+    @pytest.fixture(autouse=True)
+    def _attach_ss(self, request, case5):
+        request.instance.ss = case5
+
+    def test_rejects_bad_user_constraint(self):
+        # Mutate a user-customized constraint to a non-LHS-zero form
+        # and confirm parse raises with the helpful error.
+        self.ss.DCOPF.plflb.e_str = 'plf <= rate_a'  # missing `- 0`
+        with self.assertRaises(ValueError) as ctx:
+            self.ss.DCOPF.plflb.parse()
+        self.assertIn('LHS-zero', str(ctx.exception))
+
+    def test_accepts_correct_user_constraint(self):
+        # Same intent, correctly authored.
+        self.ss.DCOPF.plflb.e_str = 'plf - rate_a <= 0'
+        self.ss.DCOPF.plflb.parse()  # must not raise
+
+
+class TestEvalEStrDcpWarning(unittest.TestCase):
+    """``eval_e_str`` logs a per-item warning on non-DCP results."""
+
+    @pytest.fixture(autouse=True)
+    def _attach_ss(self, request, case5):
+        request.instance.ss = case5
+
+    def test_warns_on_non_dcp(self):
+        # Author a non-DCP product: ``cp.multiply(pg, pg)`` is non-convex
+        # (use ``cp.square(pg)`` instead). Going through addConstrs forces
+        # the eval-fallback path.
+        self.ss.DCOPF.init()  # codegen wires built-ins; clean state
+        self.ss.DCOPF.addConstrs(
+            name='nonconvex_demo',
+            e_str='cp.multiply(pg, pg) - 1 <= 0',
+        )
+        with self.assertLogs('ams.opt._runtime_eval', level='WARNING') as cm:
+            self.ss.DCOPF.nonconvex_demo.parse()
+            self.ss.DCOPF.nonconvex_demo.evaluate()
+        self.assertTrue(
+            any('non-DCP' in m for m in cm.output),
+            f'expected non-DCP warning, got: {cm.output}',
+        )
+
+    def test_no_warning_on_dcp(self):
+        # Sanity: a normal LHS-zero constraint must not emit the warning.
+        self.ss.DCOPF.init()
+        self.ss.DCOPF.addConstrs(
+            name='dcp_demo',
+            e_str='cp.square(pg) - 100 <= 0',
+        )
+        logger = logging.getLogger('ams.opt._runtime_eval')
+        # Force a handler so assertLogs has something to attach to even
+        # when no record is emitted.
+        with self.assertLogs(logger, level='WARNING') as cm:
+            logger.warning('sentinel')  # ensure cm.output is non-empty
+            self.ss.DCOPF.dcp_demo.parse()
+            self.ss.DCOPF.dcp_demo.evaluate()
+        self.assertFalse(
+            any('non-DCP' in m and 'dcp_demo' in m for m in cm.output),
+            f'unexpected non-DCP warning: {cm.output}',
+        )
+
+
+class TestReservedAtomNamesDerivation(unittest.TestCase):
+    """:data:`RESERVED_CVXPY_ATOM_NAMES` is dynamic + a strict superset
+    of the static fallback."""
+
+    def test_static_is_subset(self):
+        self.assertTrue(
+            _STATIC_RESERVED_CVXPY_ATOM_NAMES.issubset(RESERVED_CVXPY_ATOM_NAMES),
+            'auto-derivation must never narrow the reserved set',
+        )
+
+    def test_includes_known_non_static_atoms(self):
+        # Atoms that exist in modern CVXPY but were not in the original
+        # static snapshot. If CVXPY removes one of these someday this
+        # test will surface that as a real signal worth investigating.
+        for atom in ('huber', 'log_sum_exp', 'quad_over_lin'):
+            with self.subTest(atom=atom):
+                if hasattr(cp, atom) and callable(getattr(cp, atom)):
+                    self.assertIn(atom, RESERVED_CVXPY_ATOM_NAMES)
+
+    def test_grew_meaningfully(self):
+        # Cheap regression check: derivation should add at least a
+        # handful of names beyond the static set on any reasonable
+        # CVXPY install.
+        new = RESERVED_CVXPY_ATOM_NAMES - _STATIC_RESERVED_CVXPY_ATOM_NAMES
+        self.assertGreaterEqual(
+            len(new), 10,
+            f'auto-derivation found only {len(new)} new atoms: {sorted(new)}',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Three small follow-ups to the cvxpy-namespace passthrough (#244-#248) and `is_eq` retirement (#249), all surfacing user-customization mistakes that previously failed silently or far from the cause. Architecture-review items L5 and M4 from the 2026-05-02 audit.

- **L5** — `Constraint.parse` now validates that `e_str` ends with `<= 0` / `== 0` / `>= 0`. A constraint authored as `pg <= pmax` solves correctly but produces a numpy bool array as `OptzBase.e` (instead of the LHS slack), because `eval_e_str_numeric`'s trailing-op stripper only matches `<op> 0`. The new `assert_constraint_lhs_zero` guard in `ams/opt/_runtime_eval.py` surfaces the mismatch immediately with an actionable error.
- **M4a** — `eval_e_str` now logs a per-item `WARNING` when the result reports `is_dcp() is False`. The codegen path skips eval entirely, so this only fires on user customizations / `addConstrs` / mixin overrides — exactly where silent DCP drift is most likely after the namespace passthrough opened the full `cp.*` surface.
- **M4b** — `RESERVED_CVXPY_ATOM_NAMES` is auto-derived from `cvxpy.atoms` at import time, unioned with the static fallback so the guarded set can only grow. Modern CVXPY exposes ~116 atom callables vs the static set of 19; future atoms are guarded automatically.
- **M4c** — Updated the trust-boundary comment in `eval_e_str` to reflect that user code rides the same path post-passthrough; the prior framing understated the actual reach.

## Test plan

- [x] `pytest tests/opt/test_runtime_eval.py` (15 new cases) — pass
- [x] `pytest tests/opt/ tests/codegen/ tests/cli/` — 42 pass
- [x] `pytest tests/routines/ tests/core/` — 244 pass
- [x] `pytest tests/` (full suite) — 363 pass, 0 fail
- [x] Spot-checked DCOPF solve on `case5.m` against pre-change output (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)