### PR TITLE
docs: fix v1.2.2 → v1.2.3 attribution + add tests-refactor bullet

### DIFF
--- a/ams/opt/constraint.py
+++ b/ams/opt/constraint.py
@@ -147,7 +147,7 @@ class Constraint(OptzBase):
                 f"cp.constraints.Constraint (embed the relational "
                 f"operator: '<LHS> <= 0', '<LHS> == 0', or '<LHS> >= 0'). "
                 f"Got {type(result).__name__}. Stale "
-                f"~/.ams/pycode/ from before the v1.2.2 is_eq retirement "
+                f"~/.ams/pycode/ from before the v1.2.3 is_eq retirement "
                 f"is auto-invalidated by PYCODE_FORMAT_VERSION; if you see "
                 f"this from a freshly-regenerated cache, the underlying "
                 f"e_str is missing its trailing operator."

--- a/ams/opt/optzbase.py
+++ b/ams/opt/optzbase.py
@@ -201,7 +201,7 @@ class OptzBase:
           symbol-by-symbol via :func:`ams.opt._runtime_eval.eval_e_str`
           and ``eval``-ed at parse/evaluate time. This is what runs for
           items the user customized via ``e_str = '...'`` or
-          ``addConstrs(...)``. (Renamed from ``'sub_map'`` in v1.2.2;
+          ``addConstrs(...)``. (Renamed from ``'sub_map'`` in v1.2.3;
           the legacy regex+eval pipeline that name referenced was
           retired in PR #246.)
         """

--- a/docs/source/modeling/migration_cvxpy_namespace.rst
+++ b/docs/source/modeling/migration_cvxpy_namespace.rst
@@ -1,9 +1,9 @@
 .. _migration_cvxpy_namespace:
 
-Migration: canonical CVXPY in ``e_str`` (v1.2.2)
+Migration: canonical CVXPY in ``e_str`` (v1.2.3)
 ==================================================
 
-v1.2.2 removes AMS's historical function-name rewrite layer for
+v1.2.3 removes AMS's historical function-name rewrite layer for
 ``e_str`` strings. ``mul``, ``multiply``, ``sum``, and the ``a dot b``
 binary syntax are no longer translated into their ``cp.*`` / ``*``
 equivalents — author canonical CVXPY directly. This page is a
@@ -282,5 +282,5 @@ See also
   covers canonical CVXPY syntax in depth.
 - ``examples/ex8.ipynb`` — sp1 / sp2 / sp3 walkthrough of post-init
   customization patterns under the canonical rules.
-- :ref:`ReleaseNotes` — v1.2.2 entry, "Migration — ``e_str``
+- :ref:`ReleaseNotes` — v1.2.3 entry, "Migration — ``e_str``
   authoring contract".

--- a/docs/source/modeling/routine.rst
+++ b/docs/source/modeling/routine.rst
@@ -91,9 +91,9 @@ the host routine. It does **not** rewrite function names: ``cp.*`` calls
 must be written explicitly.
 
 .. note::
-   Prior to v1.2.2, AMS rewrote ``mul(...)`` → ``cp.multiply(...)``,
+   Prior to v1.2.3, AMS rewrote ``mul(...)`` → ``cp.multiply(...)``,
    bare ``sum(...)`` → ``cp.sum(...)``, and ``a dot b`` → ``a * b``
-   automatically. That rewrite layer has been removed — see the v1.2.2
+   automatically. That rewrite layer has been removed — see the v1.2.3
    migration table in :ref:`ReleaseNotes`. User customizations
    (``addConstrs(e_str=...)`` / ``obj.e_str += '...'``) that still use
    the old vocabulary will raise ``NameError`` at eval time.
@@ -137,7 +137,7 @@ Other canonical-CVXPY constructs in ``e_str``:
 * Comparisons ``... == 0`` / ``... <= 0`` / ``... >= 0`` are
   embedded in the ``e_str`` itself; the LHS-zero authoring
   convention keeps ``Constraint.v`` reporting slack-from-zero
-  uniformly. See :ref:`migration_cvxpy_namespace` for the v1.2.2
+  uniformly. See :ref:`migration_cvxpy_namespace` for the v1.2.3
   ``is_eq`` retirement.
 * Powers use ``**`` (e.g. ``vmax**2``).
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -138,6 +138,15 @@ new name reflects the live implementation —
   :func:`ams.routines.routine.gather_results` with a keyword-only
   ``group`` flag selecting the flat (CSV) vs nested (JSON) output
   shape. Closes issue #195.
+- ``tests/`` reorganized into per-source-layer subfolders mirroring
+  ``ams/`` (``tests/io/``, ``tests/opt/``, ``tests/routines/``,
+  ``tests/system/``, ``tests/models/``, ``tests/core/``,
+  ``tests/interop/``, ``tests/cli/``). Shared case fixtures
+  (``case5``, ``case14``, ``case_pjm5bus_demo``, …) extracted to
+  ``tests/conftest.py``; Family-A and Family-B–E routine scenarios
+  consolidated into parametrized cross-checks; MATPOWER known-good
+  comparisons parametrized. New ``docs/source/modeling/test_layout.rst``
+  documents the layout. Net: -3 600 lines duplicated boilerplate.
 
 v1.2.2 (2026-05-01)
 ----------------------

--- a/examples/demonstration/demo_debug.ipynb
+++ b/examples/demonstration/demo_debug.ipynb
@@ -502,7 +502,7 @@
     "\n",
     "Every routine constraint is authored in the **LHS-zero form** —\n",
     "all terms on the left, `<= 0` / `== 0` / `>= 0` on the right\n",
-    "(post-v1.2.2; see the `is_eq` retirement migration). CVXPY then\n",
+    "(post-v1.2.3; see the `is_eq` retirement migration). CVXPY then\n",
     "canonicalizes every inequality internally to `lhs - rhs <= 0`\n",
     "**regardless of operator direction**:\n",
     "\n",

--- a/examples/ex8.ipynb
+++ b/examples/ex8.ipynb
@@ -497,7 +497,7 @@
     "sp2.DCOPF.addService(name='te', tex_name='t_e', info='emission cap', value=1.0)\n",
     "sp2.DCOPF.addVars(name='eg', tex_name='e_g', info='gen emission',\n",
     "                   unit='t', model='StaticGen')\n",
-    "# is_eq retired in v1.2.2 — embed the relational operator in e_str\n",
+    "# is_eq retired in v1.2.3 — embed the relational operator in e_str\n",
     "# directly. LHS-zero discipline keeps `.v` reporting slack-from-zero\n",
     "# (negative = respected, positive = violated) regardless of `<=`/`>=`\n",
     "# direction (CVXPY canonicalizes both to `lhs - rhs <= 0` internally).\n",


### PR DESCRIPTION
Addresses the two themes from the PR #259 reviewer agent's findings.

## 1. v1.2.2 → v1.2.3 attribution (5 files, ~6 line edits)

The cvxpy-namespace migration + \`is_eq\` retirement actually ship in v1.2.3 (per release-notes.rst), but several files still attributed the change to v1.2.2 — leftover from when this work was originally drafted under a stale \`v1.2.2 (unreleased)\` header.

- \`docs/source/modeling/migration_cvxpy_namespace.rst\` — page title, intro paragraph, ReleaseNotes cross-ref
- \`docs/source/modeling/routine.rst\` — rewrite-removal note, \`is_eq\` cross-ref
- \`ams/opt/constraint.py\` — user-facing \`TypeError\` message about stale pycode
- \`ams/opt/optzbase.py\` — \`formulation_source\` docstring
- \`examples/ex8.ipynb\` — sp2 customization comment
- \`examples/demonstration/demo_debug.ipynb\` — LHS-zero rationale

## 2. Tests-refactor bullet (release-notes.rst)

The v1.2.3 \`**Internal:**\` section was missing PRs #250–#255 entirely. Added a bullet describing the \`tests/<layer>/\` reorganization, the shared \`conftest.py\` fixtures, scenario consolidation, MATPOWER parametrization, and the new \`docs/source/modeling/test_layout.rst\`.

Notebook patches edit cell source in place (preserving outputs) rather than via NotebookEdit (which clears outputs).

## Test plan
- [x] Smoke-tested affected code paths: \`pytest tests/opt/test_runtime_eval.py\` — 15 passed.
- [ ] CI matrix + RTD on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)