### PR TITLE
docs(service): add selection guide, regroup classes, document .v caching

### DIFF
--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -1,5 +1,49 @@
 """
-Service.
+Routine services — operations and transformations on routine arrays.
+
+Service selection guide
+=======================
+
+Pick a service by what you need; subclass :class:`ROperationService`
+only if none of the existing ones fits.
+
+============================  ==========================================
+Need                          Use
+============================  ==========================================
+Wrap a precomputed ndarray    :class:`ValueService`
+Apply ``f(u.v, **args)``      :class:`NumOp`           (workhorse)
+Apply ``f(u.v, u2.v, ...)``   :class:`NumOpDual`       (e.g. multiply)
+Repeat ``u`` across columns   :class:`NumHstack`       (broadcast)
+Pick gen subset by indexer    :class:`VarSelect`
+Sum into zones / areas        :class:`ZonalSum`
+Ramp difference matrix        :class:`RampSub`
+Shape-only reduction matrix   :class:`VarReduction`
+Zonal load scaling            :class:`LoadScale`       (load-status aware)
+UC min on/off duration        :class:`MinDur`          (UC routines only)
+============================  ==========================================
+
+Notes
+-----
+- The ``expand_dims=axis`` kwarg on :class:`NumOp` covers the
+  :class:`NumExpandDim` use case; ``NumExpandDim`` is retained as a
+  thin alias for backward compatibility — prefer ``NumOp`` directly.
+- :class:`MinDur` inherits from :class:`NumOpDual` for parameter
+  plumbing only; the inherited ``fun``/``rfun`` machinery is unused.
+- ``.v`` caching: subclasses recompute fresh on every access — there
+  is no framework-level cache. Only :class:`ValueService` returns a
+  stored value. Memoize at the routine level if a tight loop is
+  hitting ``.v`` repeatedly.
+
+File layout
+-----------
+1. Bases (``RBaseService``, ``ROperationService``)
+2. Static storage (``ValueService``)
+3. Generic single-input ops (``NumOp``, ``NumHstack``)
+4. Generic dual-input ops (``NumOpDual``)
+5. Subset / aggregation (``VarSelect``, ``ZonalSum``)
+6. Reduction / difference (``RampSub``, ``VarReduction``)
+7. Domain-specific (``LoadScale``, ``MinDur``)
+8. Backward-compat alias (``NumExpandDim``)
 """
 
 import logging
@@ -14,6 +58,11 @@ from ams.opt import Param
 
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 1. Bases
+# ---------------------------------------------------------------------------
 
 
 class RBaseService(BaseService, Param):
@@ -71,6 +120,11 @@ class RBaseService(BaseService, Param):
     def v(self):
         """
         Value of the service.
+
+        Caching contract: returns ``None`` at the base. Subclasses
+        recompute fresh on every access (no framework-level cache);
+        :class:`ValueService` is the only exception — it returns the
+        stored ndarray. Memoize at the routine level if needed.
         """
         return None
 
@@ -86,6 +140,50 @@ class RBaseService(BaseService, Param):
             return f'{self.class_name}: {self.rtn.class_name}'
         else:
             return f'{self.class_name}: {self.rtn.class_name}.{self.name}'
+
+
+class ROperationService(RBaseService):
+    """
+    Base calss for operational services used in routine.
+
+    Parameters
+    ----------
+    u : Callable
+        Input.
+    name : str, optional
+        Instance name.
+    tex_name : str, optional
+        TeX name.
+    unit : str, optional
+        Unit.
+    info : str, optional
+        Description.
+    vtype : Type, optional
+        Variable type.
+    no_parse: bool, optional
+        True to skip parsing the service.
+    sparse: bool, optional
+        True to return output as scipy csr_matrix.
+    """
+
+    def __init__(self,
+                 u: Callable,
+                 name: str = None,
+                 tex_name: str = None,
+                 unit: str = None,
+                 info: str = None,
+                 vtype: Type = None,
+                 no_parse: bool = False,
+                 sparse: bool = False,):
+        super().__init__(name=name, tex_name=tex_name, unit=unit,
+                         info=info, vtype=vtype,
+                         no_parse=no_parse, sparse=sparse)
+        self.u = u
+
+
+# ---------------------------------------------------------------------------
+# 2. Static value storage
+# ---------------------------------------------------------------------------
 
 
 class ValueService(RBaseService):
@@ -128,110 +226,17 @@ class ValueService(RBaseService):
     @property
     def v(self):
         """
-        Value of the service.
+        Value of the service. Returns the stored ndarray (cached;
+        the only service that does so).
         """
         if self.sparse:
             return spr.csr_matrix(self._v)
         return self._v
 
 
-class ROperationService(RBaseService):
-    """
-    Base calss for operational services used in routine.
-
-    Parameters
-    ----------
-    u : Callable
-        Input.
-    name : str, optional
-        Instance name.
-    tex_name : str, optional
-        TeX name.
-    unit : str, optional
-        Unit.
-    info : str, optional
-        Description.
-    vtype : Type, optional
-        Variable type.
-    no_parse: bool, optional
-        True to skip parsing the service.
-    sparse: bool, optional
-        True to return output as scipy csr_matrix.
-    """
-
-    def __init__(self,
-                 u: Callable,
-                 name: str = None,
-                 tex_name: str = None,
-                 unit: str = None,
-                 info: str = None,
-                 vtype: Type = None,
-                 no_parse: bool = False,
-                 sparse: bool = False,):
-        super().__init__(name=name, tex_name=tex_name, unit=unit,
-                         info=info, vtype=vtype,
-                         no_parse=no_parse, sparse=sparse)
-        self.u = u
-
-
-class LoadScale(ROperationService):
-    """
-    Retrieve zonal load by scaling nodal load using the specified load scale factor.
-    The load scale factor is defined for each "Area".
-
-    In this class, load status is considered.
-
-    Parameters
-    ----------
-    u : Callable
-        nodal load, should be a `RParam` instance, with model `StaticLoad`.
-    sd : Callable
-        zonal load factor.
-    name : str, optional
-        Instance name.
-    tex_name : str, optional
-        TeX name.
-    unit : str, optional
-        Unit.
-    info : str, optional
-        Description.
-    no_parse: bool, optional
-        True to skip parsing the service.
-    sparse: bool, optional
-        True to return output as scipy csr_matrix.
-    """
-
-    def __init__(self,
-                 u: Callable,
-                 sd: Callable,
-                 name: str = None,
-                 tex_name: str = None,
-                 unit: str = None,
-                 info: str = None,
-                 no_parse: bool = False,
-                 sparse: bool = False,
-                 ):
-        tex_name = tex_name if tex_name is not None else u.tex_name
-        super().__init__(name=name, tex_name=tex_name, unit=unit,
-                         info=info, u=u, no_parse=no_parse,
-                         sparse=sparse)
-        self.sd = sd
-
-    @property
-    def v(self):
-        sys = self.rtn.system
-        u_idx = self.u.get_all_idxes()
-        ue = self.u.owner.get(src='u', attr='v', idx=u_idx)
-        u_bus = self.u.owner.get(src='bus', attr='v', idx=u_idx)
-        u_area = sys.Bus.get(src='area', attr='v', idx=u_bus)
-        u_yloc = np.array(sys.Area.idx2uid(u_area))
-        # sd.v is (narea, nslot) post-v1.3.0; index by area-uid on the
-        # primary axis directly to obtain the (nbus, nslot) view.
-        p0s = np.multiply(self.sd.v[u_yloc, :],
-                          (ue * self.u.v)[:, np.newaxis])
-        if self.sparse:
-            return spr.csr_matrix(p0s)
-        return p0s
+# ---------------------------------------------------------------------------
+# 3. Generic operations — single input
+# ---------------------------------------------------------------------------
 
 
 class NumOp(ROperationService):
@@ -329,17 +334,20 @@ class NumOp(ROperationService):
         return out
 
 
-class NumExpandDim(NumOp):
+class NumHstack(NumOp):
     """
-    Expand the dimensions of the input array along a specified axis
-    using NumPy's ``np.expand_dims(u.v, axis=axis)``.
+    Repeat an array along the second axis nc times or the length of
+    reference array,
+    using NumPy's hstack function, where nc is the column number of the
+    reference array,
+    ``np.hstack([u.v[:, np.newaxis] * ref.shape[1]], **kwargs)``.
 
     Parameters
     ----------
     u : Callable
-        Input.
-    axis : int
-        Axis along which to expand the dimensions (default is 0).
+        Input array.
+    ref : Callable
+        Reference array used to determine the number of repetitions.
     name : str, optional
         Instance name.
     tex_name : str, optional
@@ -350,37 +358,52 @@ class NumExpandDim(NumOp):
         Description.
     vtype : Type, optional
         Variable type.
-    array_out : bool, optional
-        Whether to force the output to be an array.
+    rfun : Callable, optional
+        Function to apply to the output of ``fun``.
+    rargs : dict, optional
+        Keyword arguments to pass to ``rfun``.
+    no_parse: bool, optional
+        True to skip parsing the service.
     sparse: bool, optional
         True to return output as scipy csr_matrix.
     """
 
     def __init__(self,
                  u: Callable,
-                 axis: int = 0,
+                 ref: Callable,
                  args: dict = None,
                  name: str = None,
                  tex_name: str = None,
                  unit: str = None,
                  info: str = None,
                  vtype: Type = None,
-                 array_out: bool = True,
+                 rfun: Callable = None,
+                 rargs: dict = None,
                  no_parse: bool = False,
                  sparse: bool = False,):
         super().__init__(name=name, tex_name=tex_name, unit=unit,
                          info=info, vtype=vtype,
-                         u=u, fun=np.expand_dims, args=args,
-                         array_out=array_out,
+                         u=u, fun=np.hstack, args=args,
+                         rfun=rfun, rargs=rargs,
                          no_parse=no_parse, sparse=sparse)
-        self.axis = axis
+        self.ref = ref
 
     @property
-    def v(self):
-        out = self.fun(self.u.v, axis=self.axis, **self.args)
-        if self.sparse:
-            return spr.csr_matrix(out)
-        return out
+    def v0(self):
+        nc = 1
+        if isinstance(self.ref.v, (list, tuple)):
+            nc = len(self.ref.v)
+        elif hasattr(self.ref, "shape"):
+            nc = self.ref.shape[1]
+        else:
+            raise AttributeError(f"{self.rtn.class_name}: ref {self.ref.name} has no attribute shape nor length.")
+        return self.fun([self.u.v[:, np.newaxis]] * nc,
+                        **self.args)
+
+
+# ---------------------------------------------------------------------------
+# 4. Generic operations — dual input
+# ---------------------------------------------------------------------------
 
 
 class NumOpDual(NumOp):
@@ -465,239 +488,9 @@ class NumOpDual(NumOp):
         return out
 
 
-class MinDur(NumOpDual):
-    """
-    Build the coefficient matrix for minimum online/offline
-    constraints used in UC.
-
-    Parameters
-    ----------
-    u : Callable
-        Input, should be a ``Var`` with horizon.
-    u2 : Callable
-        Input2, should be a ``RParam``.
-    name : str, optional
-        Instance name.
-    tex_name : str, optional
-        TeX name.
-    unit : str, optional
-        Unit.
-    info : str, optional
-        Description.
-    vtype : Type, optional
-        Variable type.
-    no_parse: bool, optional
-        True to skip parsing the service.
-    sparse: bool, optional
-        True to return output as scipy csr_matrix.
-    """
-
-    def __init__(self,
-                 u: Callable,
-                 u2: Callable,
-                 name: str = None,
-                 tex_name: str = None,
-                 unit: str = None,
-                 info: str = None,
-                 vtype: Type = None,
-                 no_parse: bool = False,
-                 sparse: bool = False,):
-        tex_name = tex_name if tex_name is not None else u.tex_name
-        super().__init__(name=name, tex_name=tex_name, unit=unit,
-                         info=info, vtype=vtype,
-                         u=u, u2=u2, fun=None, args=None,
-                         rfun=None, rargs=None,
-                         expand_dims=None,
-                         no_parse=no_parse, sparse=sparse)
-        if self.u.horizon is None:
-            msg = f'{self.class_name} <{self.name}>.u: <{self.u.name}> '
-            msg += 'has no horizon, likely a modeling error.'
-            logger.error(msg)
-
-    @property
-    def v(self):
-        n_gen = self.u.n
-        n_ts = self.u.horizon.n
-        tout = np.zeros((n_gen, n_ts))
-        t = self.rtn.config.t  # scheduling interval
-
-        # minimum online/offline duration
-        td = np.ceil(self.u2.v/t).astype(int)
-
-        # Create index arrays for generators and time periods
-        i, t = np.meshgrid(np.arange(n_gen), np.arange(n_ts), indexing='ij')
-        # Create a mask for valid time periods based on minimum duration
-        valid_mask = (t + td[i] <= n_ts)
-        tout[i[valid_mask], t[valid_mask]] = 1
-        if self.sparse:
-            return spr.csr_matrix(tout)
-        return tout
-
-
-class NumHstack(NumOp):
-    """
-    Repeat an array along the second axis nc times or the length of
-    reference array,
-    using NumPy's hstack function, where nc is the column number of the
-    reference array,
-    ``np.hstack([u.v[:, np.newaxis] * ref.shape[1]], **kwargs)``.
-
-    Parameters
-    ----------
-    u : Callable
-        Input array.
-    ref : Callable
-        Reference array used to determine the number of repetitions.
-    name : str, optional
-        Instance name.
-    tex_name : str, optional
-        TeX name.
-    unit : str, optional
-        Unit.
-    info : str, optional
-        Description.
-    vtype : Type, optional
-        Variable type.
-    rfun : Callable, optional
-        Function to apply to the output of ``fun``.
-    rargs : dict, optional
-        Keyword arguments to pass to ``rfun``.
-    no_parse: bool, optional
-        True to skip parsing the service.
-    sparse: bool, optional
-        True to return output as scipy csr_matrix.
-    """
-
-    def __init__(self,
-                 u: Callable,
-                 ref: Callable,
-                 args: dict = None,
-                 name: str = None,
-                 tex_name: str = None,
-                 unit: str = None,
-                 info: str = None,
-                 vtype: Type = None,
-                 rfun: Callable = None,
-                 rargs: dict = None,
-                 no_parse: bool = False,
-                 sparse: bool = False,):
-        super().__init__(name=name, tex_name=tex_name, unit=unit,
-                         info=info, vtype=vtype,
-                         u=u, fun=np.hstack, args=args,
-                         rfun=rfun, rargs=rargs,
-                         no_parse=no_parse, sparse=sparse)
-        self.ref = ref
-
-    @property
-    def v0(self):
-        nc = 1
-        if isinstance(self.ref.v, (list, tuple)):
-            nc = len(self.ref.v)
-        elif hasattr(self.ref, "shape"):
-            nc = self.ref.shape[1]
-        else:
-            raise AttributeError(f"{self.rtn.class_name}: ref {self.ref.name} has no attribute shape nor length.")
-        return self.fun([self.u.v[:, np.newaxis]] * nc,
-                        **self.args)
-
-
-class ZonalSum(NumOp):
-    """
-    Build zonal sum matrix for a vector in the shape of collection model,
-    ``Area`` or ``Zone``.
-    The value array is in the shape of (nr, nc), where nr is the length of
-    rid instance idx, and nc is the length of the cid value.
-
-    In an IEEE-14 Bus system, we have the zonal definition by the
-    ``Zone`` model. Suppose in it we have two regions, "ZONE1" and
-    "ZONE2".
-
-    Follwing it, we have a zonal SFR requirement model ``SFR`` that
-    defines the zonal reserve requirements for each zone.
-
-    All 14 buses are classified to a zone by the `IdxParam` ``zone``,
-    and the 5 generators are connected to buses
-    (idx): [2, 3, 1, 6, 8], and the zone of these generators are thereby:
-    ['ZONE1', 'ZONE1', 'ZONE2', 'ZONE2', 'ZONE1'].
-
-    In the `RTED` model, we have the Vars ``pru`` and ``prd`` in the
-    shape of generators.
-
-    Then, the Zone model has idx ['ZONE1', 'ZONE2'], and the ``gsm`` value
-    will be [[1, 1, 0, 0, 1], [0, 0, 1, 1, 0]].
-
-    Finally, the zonal reserve requirements can be formulated as
-    constraints in the optimization problem: "gsm @ pru <= du" and
-    "gsm @ prd <= dd".
-
-    See ``gsm`` definition in :py:mod:`ams.routines.rted.RTEDModel` for
-    more details.
-
-    Parameters
-    ----------
-    u : Callable
-        Input.
-    zone : str
-        Zonal model name, e.g., "Area" or "Zone".
-    name : str
-        Instance name.
-    tex_name : str
-        TeX name.
-    unit : str
-        Unit.
-    info : str
-        Description.
-    vtype : Type
-        Variable type.
-    rfun : Callable, optional
-        Function to apply to the output of ``fun``.
-    rargs : dict, optional
-        Keyword arguments to pass to ``rfun``.
-    no_parse: bool, optional
-        True to skip parsing the service.
-    sparse: bool, optional
-        True to return output as scipy csr_matrix.
-    """
-
-    def __init__(self,
-                 u: Callable,
-                 zone: str,
-                 name: str = None,
-                 tex_name: str = None,
-                 unit: str = None,
-                 info: str = None,
-                 vtype: Type = None,
-                 rfun: Callable = None,
-                 rargs: dict = None,
-                 no_parse: bool = False,
-                 sparse: bool = False,):
-        super().__init__(name=name, tex_name=tex_name, unit=unit,
-                         info=info, vtype=vtype,
-                         u=u, fun=None, args={},
-                         rfun=rfun, rargs=rargs,
-                         no_parse=no_parse, sparse=sparse)
-        self.zone = zone
-
-    @property
-    def v0(self):
-        try:
-            zone_mdl = getattr(self.rtn.system, self.zone)
-        except AttributeError:
-            raise AttributeError(f'Zonal model <{self.zone}> not found.')
-        ridx = None
-        try:
-            ridx = zone_mdl.idx.v
-        except AttributeError:
-            ridx = zone_mdl.get_all_idxes()
-
-        row, col = np.meshgrid(self.u.v, ridx)
-        # consistency check
-        is_subset = set(self.u.v).issubset(set(ridx))
-        if not is_subset:
-            raise ValueError(f'{self.u.model} contains undefined zone, likey a data error.')
-        result = (row == col).astype(int)
-
-        return result
+# ---------------------------------------------------------------------------
+# 5. Subset / aggregation
+# ---------------------------------------------------------------------------
 
 
 class VarSelect(NumOp):
@@ -811,27 +604,54 @@ class VarSelect(NumOp):
         return out
 
 
-class VarReduction(NumOp):
+class ZonalSum(NumOp):
     """
-    A numerical matrix to reduce a 2D variable to 1D,
-    ``np.fun(shape=(1, u.n))``.
+    Build zonal sum matrix for a vector in the shape of collection model,
+    ``Area`` or ``Zone``.
+    The value array is in the shape of (nr, nc), where nr is the length of
+    rid instance idx, and nc is the length of the cid value.
+
+    In an IEEE-14 Bus system, we have the zonal definition by the
+    ``Zone`` model. Suppose in it we have two regions, "ZONE1" and
+    "ZONE2".
+
+    Follwing it, we have a zonal SFR requirement model ``SFR`` that
+    defines the zonal reserve requirements for each zone.
+
+    All 14 buses are classified to a zone by the `IdxParam` ``zone``,
+    and the 5 generators are connected to buses
+    (idx): [2, 3, 1, 6, 8], and the zone of these generators are thereby:
+    ['ZONE1', 'ZONE1', 'ZONE2', 'ZONE2', 'ZONE1'].
+
+    In the `RTED` model, we have the Vars ``pru`` and ``prd`` in the
+    shape of generators.
+
+    Then, the Zone model has idx ['ZONE1', 'ZONE2'], and the ``gsm`` value
+    will be [[1, 1, 0, 0, 1], [0, 0, 1, 1, 0]].
+
+    Finally, the zonal reserve requirements can be formulated as
+    constraints in the optimization problem: "gsm @ pru <= du" and
+    "gsm @ prd <= dd".
+
+    See ``gsm`` definition in :py:mod:`ams.routines.rted.RTEDModel` for
+    more details.
 
     Parameters
     ----------
     u : Callable
-        The input matrix variable.
-    fun : Callable
-        The reduction function that takes a shape argument (1D shape) as input.
-    name : str, optional
-        The name of the instance.
-    tex_name : str, optional
-        The TeX name for the instance.
-    unit : str, optional
-        The unit of the output.
-    info : str, optional
-        A description of the operation.
-    vtype : Type, optional
-        The variable type.
+        Input.
+    zone : str
+        Zonal model name, e.g., "Area" or "Zone".
+    name : str
+        Instance name.
+    tex_name : str
+        TeX name.
+    unit : str
+        Unit.
+    info : str
+        Description.
+    vtype : Type
+        Variable type.
     rfun : Callable, optional
         Function to apply to the output of ``fun``.
     rargs : dict, optional
@@ -844,7 +664,7 @@ class VarReduction(NumOp):
 
     def __init__(self,
                  u: Callable,
-                 fun: Callable,
+                 zone: str,
                  name: str = None,
                  tex_name: str = None,
                  unit: str = None,
@@ -856,13 +676,36 @@ class VarReduction(NumOp):
                  sparse: bool = False,):
         super().__init__(name=name, tex_name=tex_name, unit=unit,
                          info=info, vtype=vtype,
-                         u=u, fun=None, rfun=rfun, rargs=rargs,
-                         no_parse=no_parse, sparse=sparse,)
-        self.fun = fun
+                         u=u, fun=None, args={},
+                         rfun=rfun, rargs=rargs,
+                         no_parse=no_parse, sparse=sparse)
+        self.zone = zone
 
     @property
     def v0(self):
-        return self.fun(shape=(1, self.u.n))
+        try:
+            zone_mdl = getattr(self.rtn.system, self.zone)
+        except AttributeError:
+            raise AttributeError(f'Zonal model <{self.zone}> not found.')
+        ridx = None
+        try:
+            ridx = zone_mdl.idx.v
+        except AttributeError:
+            ridx = zone_mdl.get_all_idxes()
+
+        row, col = np.meshgrid(self.u.v, ridx)
+        # consistency check
+        is_subset = set(self.u.v).issubset(set(ridx))
+        if not is_subset:
+            raise ValueError(f'{self.u.model} contains undefined zone, likey a data error.')
+        result = (row == col).astype(int)
+
+        return result
+
+
+# ---------------------------------------------------------------------------
+# 6. Reduction / difference matrices
+# ---------------------------------------------------------------------------
 
 
 class RampSub(NumOp):
@@ -930,6 +773,263 @@ class RampSub(NumOp):
     def v(self):
         nr = self.u.horizon.n
         out = np.eye(nr, nr-1, k=-1) - np.eye(nr, nr-1, k=0)
+        if self.sparse:
+            return spr.csr_matrix(out)
+        return out
+
+
+class VarReduction(NumOp):
+    """
+    A numerical matrix to reduce a 2D variable to 1D,
+    ``np.fun(shape=(1, u.n))``.
+
+    Parameters
+    ----------
+    u : Callable
+        The input matrix variable.
+    fun : Callable
+        The reduction function that takes a shape argument (1D shape) as input.
+    name : str, optional
+        The name of the instance.
+    tex_name : str, optional
+        The TeX name for the instance.
+    unit : str, optional
+        The unit of the output.
+    info : str, optional
+        A description of the operation.
+    vtype : Type, optional
+        The variable type.
+    rfun : Callable, optional
+        Function to apply to the output of ``fun``.
+    rargs : dict, optional
+        Keyword arguments to pass to ``rfun``.
+    no_parse: bool, optional
+        True to skip parsing the service.
+    sparse: bool, optional
+        True to return output as scipy csr_matrix.
+    """
+
+    def __init__(self,
+                 u: Callable,
+                 fun: Callable,
+                 name: str = None,
+                 tex_name: str = None,
+                 unit: str = None,
+                 info: str = None,
+                 vtype: Type = None,
+                 rfun: Callable = None,
+                 rargs: dict = None,
+                 no_parse: bool = False,
+                 sparse: bool = False,):
+        super().__init__(name=name, tex_name=tex_name, unit=unit,
+                         info=info, vtype=vtype,
+                         u=u, fun=None, rfun=rfun, rargs=rargs,
+                         no_parse=no_parse, sparse=sparse,)
+        self.fun = fun
+
+    @property
+    def v0(self):
+        return self.fun(shape=(1, self.u.n))
+
+
+# ---------------------------------------------------------------------------
+# 7. Domain-specific
+# ---------------------------------------------------------------------------
+
+
+class LoadScale(ROperationService):
+    """
+    Retrieve zonal load by scaling nodal load using the specified load scale factor.
+    The load scale factor is defined for each "Area".
+
+    In this class, load status is considered.
+
+    Parameters
+    ----------
+    u : Callable
+        nodal load, should be a `RParam` instance, with model `StaticLoad`.
+    sd : Callable
+        zonal load factor.
+    name : str, optional
+        Instance name.
+    tex_name : str, optional
+        TeX name.
+    unit : str, optional
+        Unit.
+    info : str, optional
+        Description.
+    no_parse: bool, optional
+        True to skip parsing the service.
+    sparse: bool, optional
+        True to return output as scipy csr_matrix.
+    """
+
+    def __init__(self,
+                 u: Callable,
+                 sd: Callable,
+                 name: str = None,
+                 tex_name: str = None,
+                 unit: str = None,
+                 info: str = None,
+                 no_parse: bool = False,
+                 sparse: bool = False,
+                 ):
+        tex_name = tex_name if tex_name is not None else u.tex_name
+        super().__init__(name=name, tex_name=tex_name, unit=unit,
+                         info=info, u=u, no_parse=no_parse,
+                         sparse=sparse)
+        self.sd = sd
+
+    @property
+    def v(self):
+        sys = self.rtn.system
+        u_idx = self.u.get_all_idxes()
+        ue = self.u.owner.get(src='u', attr='v', idx=u_idx)
+        u_bus = self.u.owner.get(src='bus', attr='v', idx=u_idx)
+        u_area = sys.Bus.get(src='area', attr='v', idx=u_bus)
+        u_yloc = np.array(sys.Area.idx2uid(u_area))
+        # sd.v is (narea, nslot) post-v1.3.0; index by area-uid on the
+        # primary axis directly to obtain the (nbus, nslot) view.
+        p0s = np.multiply(self.sd.v[u_yloc, :],
+                          (ue * self.u.v)[:, np.newaxis])
+        if self.sparse:
+            return spr.csr_matrix(p0s)
+        return p0s
+
+
+class MinDur(NumOpDual):
+    """
+    Build the coefficient matrix for minimum online/offline
+    constraints used in UC.
+
+    Note: inherits from :class:`NumOpDual` for parameter plumbing only.
+    The parent's ``fun``/``rfun``/``args`` machinery is unused; this
+    class fully overrides ``.v`` to build the duration matrix from
+    ``u`` (a horizon-bearing :class:`Var`) and ``u2`` (a
+    :class:`RParam` carrying the minimum duration in time units).
+
+    Parameters
+    ----------
+    u : Callable
+        Input, should be a ``Var`` with horizon.
+    u2 : Callable
+        Input2, should be a ``RParam``.
+    name : str, optional
+        Instance name.
+    tex_name : str, optional
+        TeX name.
+    unit : str, optional
+        Unit.
+    info : str, optional
+        Description.
+    vtype : Type, optional
+        Variable type.
+    no_parse: bool, optional
+        True to skip parsing the service.
+    sparse: bool, optional
+        True to return output as scipy csr_matrix.
+    """
+
+    def __init__(self,
+                 u: Callable,
+                 u2: Callable,
+                 name: str = None,
+                 tex_name: str = None,
+                 unit: str = None,
+                 info: str = None,
+                 vtype: Type = None,
+                 no_parse: bool = False,
+                 sparse: bool = False,):
+        tex_name = tex_name if tex_name is not None else u.tex_name
+        super().__init__(name=name, tex_name=tex_name, unit=unit,
+                         info=info, vtype=vtype,
+                         u=u, u2=u2, fun=None, args=None,
+                         rfun=None, rargs=None,
+                         expand_dims=None,
+                         no_parse=no_parse, sparse=sparse)
+        if self.u.horizon is None:
+            msg = f'{self.class_name} <{self.name}>.u: <{self.u.name}> '
+            msg += 'has no horizon, likely a modeling error.'
+            logger.error(msg)
+
+    @property
+    def v(self):
+        n_gen = self.u.n
+        n_ts = self.u.horizon.n
+        tout = np.zeros((n_gen, n_ts))
+        t = self.rtn.config.t  # scheduling interval
+
+        # minimum online/offline duration
+        td = np.ceil(self.u2.v/t).astype(int)
+
+        # Create index arrays for generators and time periods
+        i, t = np.meshgrid(np.arange(n_gen), np.arange(n_ts), indexing='ij')
+        # Create a mask for valid time periods based on minimum duration
+        valid_mask = (t + td[i] <= n_ts)
+        tout[i[valid_mask], t[valid_mask]] = 1
+        if self.sparse:
+            return spr.csr_matrix(tout)
+        return tout
+
+
+# ---------------------------------------------------------------------------
+# 8. Backward-compat aliases — prefer the parent class for new code
+# ---------------------------------------------------------------------------
+
+
+class NumExpandDim(NumOp):
+    """
+    Expand the dimensions of the input array along a specified axis
+    using NumPy's ``np.expand_dims(u.v, axis=axis)``.
+
+    .. note::
+       Prefer ``NumOp(..., expand_dims=axis)`` for new code; this class
+       is retained for backward compatibility and may be deprecated.
+
+    Parameters
+    ----------
+    u : Callable
+        Input.
+    axis : int
+        Axis along which to expand the dimensions (default is 0).
+    name : str, optional
+        Instance name.
+    tex_name : str, optional
+        TeX name.
+    unit : str, optional
+        Unit.
+    info : str, optional
+        Description.
+    vtype : Type, optional
+        Variable type.
+    array_out : bool, optional
+        Whether to force the output to be an array.
+    sparse: bool, optional
+        True to return output as scipy csr_matrix.
+    """
+
+    def __init__(self,
+                 u: Callable,
+                 axis: int = 0,
+                 args: dict = None,
+                 name: str = None,
+                 tex_name: str = None,
+                 unit: str = None,
+                 info: str = None,
+                 vtype: Type = None,
+                 array_out: bool = True,
+                 no_parse: bool = False,
+                 sparse: bool = False,):
+        super().__init__(name=name, tex_name=tex_name, unit=unit,
+                         info=info, vtype=vtype,
+                         u=u, fun=np.expand_dims, args=args,
+                         array_out=array_out,
+                         no_parse=no_parse, sparse=sparse)
+        self.axis = axis
+
+    @property
+    def v(self):
+        out = self.fun(self.u.v, axis=self.axis, **self.args)
         if self.sparse:
             return spr.csr_matrix(out)
         return out

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -150,6 +150,17 @@ later resolve), reset the flag explicitly after the load:
    ss.DCOPF.load_json(path)
    ss.DCOPF.converged = False  # opt out of the new behavior
 
+**Documentation — service module selection guide:**
+
+:mod:`ams.core.service` now opens with a "service selection guide"
+table mapping common needs to the right :class:`ROperationService`
+subclass, plus a documented ``.v`` caching contract on
+:class:`~ams.core.service.RBaseService` (subclasses recompute fresh
+on each access; only :class:`~ams.core.service.ValueService` returns
+a stored value). Class definitions are regrouped by category
+(generic ops → subset/aggregation → reduction/difference →
+domain-specific → backward-compat aliases). No public API changes.
+
 v1.2
 ==========
 


### PR DESCRIPTION
## Summary

- **Module docstring** in `ams/core/service.py` now opens with a service selection guide table mapping common needs (apply `f(u.v)`, pick gen subset, sum into zones, etc.) to the right `ROperationService` subclass. Addresses the audit finding that all 13 services have overlapping prefixes (`NumOp` / `NumOpDual` / `NumExpandDim` / `NumHstack`) and no decision guide.
- **Class definitions regrouped** by category with section banners: bases → static storage → generic single-input (`NumOp`, `NumHstack`) → generic dual-input (`NumOpDual`) → subset/aggregation (`VarSelect`, `ZonalSum`) → reduction/difference (`RampSub`, `VarReduction`) → domain-specific (`LoadScale`, `MinDur`) → backward-compat aliases (`NumExpandDim`). Previously zone-related classes were scattered across lines 177, 604, 703.
- **Caching contract documented** on `RBaseService.v`: subclasses recompute fresh on every access; only `ValueService` returns a stored value. `MinDur` docstring now calls out that the `NumOpDual` inheritance is structural only (parent's `fun`/`u2`/`rfun` machinery is unused). `NumExpandDim` docstring redirects new code to `NumOp(..., expand_dims=)`.

## Scope

No public API changes — all 13 class names, signatures, and behavior preserved 1:1. This is the first of three PRs in `projects/service_module_cleanup/`:

- **Phase 1 (this PR):** docs + structure (proposals A, E, F from the audit).
- **Phase 2 (next PR):** deprecate `NumExpandDim` and `VarReduction` (both have **zero external uses** in `ams/routines/` and `ams/core/`).
- **Phase 3 (later):** share the scalar-wrap helper between `NumOp.v0` and `NumOpDual.v0` (currently 25-line near-duplicate).

## Test plan

- [x] `pytest tests/` — 395 passed, 9 subtests passed
- [x] `cd docs && make html SPHINXOPTS="-W --keep-going"` — clean
- [x] Smoke check: all 13 classes still import from `ams.core.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)