### PR TITLE
refactor(service): deprecate NumExpandDim/VarReduction; share scalar-wrap helper

### DIFF
--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -25,8 +25,10 @@ UC min on/off duration        :class:`MinDur`          (UC routines only)
 Notes
 -----
 - The ``expand_dims=axis`` kwarg on :class:`NumOp` covers the
-  :class:`NumExpandDim` use case; ``NumExpandDim`` is retained as a
-  thin alias for backward compatibility — prefer ``NumOp`` directly.
+  :class:`NumExpandDim` use case. ``NumExpandDim`` is **deprecated
+  in v1.3.0** and slated for removal in v1.4.0 — use ``NumOp``
+  directly. :class:`VarReduction` is likewise deprecated (no
+  production users); inline the reduction matrix instead.
 - :class:`MinDur` inherits from :class:`NumOpDual` for parameter
   plumbing only; the inherited ``fun``/``rfun`` machinery is unused.
 - ``.v`` caching: subclasses recompute fresh on every access — there
@@ -47,6 +49,7 @@ File layout
 """
 
 import logging
+import warnings
 from typing import Callable, Type
 
 import numpy as np
@@ -58,6 +61,22 @@ from ams.opt import Param
 
 
 logger = logging.getLogger(__name__)
+
+
+def _ensure_array(out):
+    """
+    Coerce a service output to an ndarray-like for downstream parsing.
+
+    Genuine Python scalars become 1-element ndarrays; ``ndarray`` and
+    ``scipy.sparse`` matrices pass through untouched; other array-likes
+    (list, tuple, ...) go through :func:`numpy.asarray`. Used by
+    :class:`NumOp` / :class:`NumOpDual` ``v0`` when ``array_out=True``.
+    """
+    if isinstance(out, np.ndarray) or spr.issparse(out):
+        return out
+    if np.isscalar(out):
+        return np.array([out])
+    return np.asarray(out)
 
 
 # ---------------------------------------------------------------------------
@@ -306,14 +325,7 @@ class NumOp(ROperationService):
     def v0(self):
         out = self.fun(self.u.v, **self.args)
         if self.array_out:
-            # wrap genuine Python scalars in a 1-element ndarray; pass
-            # ndarrays and scipy.sparse matrices through untouched;
-            # convert other array-likes (lists/tuples) via np.asarray
-            if not isinstance(out, np.ndarray) and not spr.issparse(out):
-                if np.isscalar(out):
-                    out = np.array([out])
-                else:
-                    out = np.asarray(out)
+            out = _ensure_array(out)
         return out
 
     @property
@@ -475,14 +487,7 @@ class NumOpDual(NumOp):
     def v0(self):
         out = self.fun(self.u.v, self.u2.v, **self.args)
         if self.array_out:
-            # wrap genuine Python scalars in a 1-element ndarray; pass
-            # ndarrays and scipy.sparse matrices through untouched;
-            # convert other array-likes (lists/tuples) via np.asarray
-            if not isinstance(out, np.ndarray) and not spr.issparse(out):
-                if np.isscalar(out):
-                    out = np.array([out])
-                else:
-                    out = np.asarray(out)
+            out = _ensure_array(out)
         if self.sparse:
             return spr.csr_matrix(out)
         return out
@@ -783,6 +788,11 @@ class VarReduction(NumOp):
     A numerical matrix to reduce a 2D variable to 1D,
     ``np.fun(shape=(1, u.n))``.
 
+    .. deprecated:: 1.3.0
+       ``VarReduction`` has no production users in AMS and will be
+       removed in v1.4.0. If you need a fixed shape-only reduction
+       matrix, build it inline (e.g. ``np.ones((1, u.n))``).
+
     Parameters
     ----------
     u : Callable
@@ -821,6 +831,12 @@ class VarReduction(NumOp):
                  rargs: dict = None,
                  no_parse: bool = False,
                  sparse: bool = False,):
+        warnings.warn(
+            "VarReduction is deprecated and will be removed in v1.4.0; "
+            "build the shape-only reduction matrix inline instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(name=name, tex_name=tex_name, unit=unit,
                          info=info, vtype=vtype,
                          u=u, fun=None, rfun=rfun, rargs=rargs,
@@ -982,9 +998,9 @@ class NumExpandDim(NumOp):
     Expand the dimensions of the input array along a specified axis
     using NumPy's ``np.expand_dims(u.v, axis=axis)``.
 
-    .. note::
-       Prefer ``NumOp(..., expand_dims=axis)`` for new code; this class
-       is retained for backward compatibility and may be deprecated.
+    .. deprecated:: 1.3.0
+       Use ``NumOp(..., expand_dims=axis)`` instead. ``NumExpandDim``
+       has no production users in AMS and will be removed in v1.4.0.
 
     Parameters
     ----------
@@ -1020,6 +1036,12 @@ class NumExpandDim(NumOp):
                  array_out: bool = True,
                  no_parse: bool = False,
                  sparse: bool = False,):
+        warnings.warn(
+            "NumExpandDim is deprecated and will be removed in v1.4.0; "
+            "use NumOp(..., expand_dims=axis) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(name=name, tex_name=tex_name, unit=unit,
                          info=info, vtype=vtype,
                          u=u, fun=np.expand_dims, args=args,

--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -17,7 +17,7 @@ Repeat ``u`` across columns   :class:`NumHstack`       (broadcast)
 Pick gen subset by indexer    :class:`VarSelect`
 Sum into zones / areas        :class:`ZonalSum`
 Ramp difference matrix        :class:`RampSub`
-Shape-only reduction matrix   :class:`VarReduction`
+Shape-only reduction matrix   inline (e.g. ``np.ones((1, u.n))``)
 Zonal load scaling            :class:`LoadScale`       (load-status aware)
 UC min on/off duration        :class:`MinDur`          (UC routines only)
 ============================  ==========================================
@@ -45,7 +45,8 @@ File layout
 5. Subset / aggregation (``VarSelect``, ``ZonalSum``)
 6. Reduction / difference (``RampSub``, ``VarReduction``)
 7. Domain-specific (``LoadScale``, ``MinDur``)
-8. Backward-compat alias (``NumExpandDim``)
+8. Deprecated, slated for removal in v1.4.0 (``NumExpandDim``,
+   ``VarReduction``)
 """
 
 import logging
@@ -989,7 +990,7 @@ class MinDur(NumOpDual):
 
 
 # ---------------------------------------------------------------------------
-# 8. Backward-compat aliases — prefer the parent class for new code
+# 8. Deprecated — slated for removal in v1.4.0
 # ---------------------------------------------------------------------------
 
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -169,10 +169,10 @@ domain-specific → backward-compat aliases). No public API changes.
 v1.4.0. Both have zero call sites in :mod:`ams.routines` and
 :mod:`ams.core`. Replacements:
 
-* ``NumExpandDim(u=…, axis=N)`` →
-  ``NumOp(u=…, fun=np.expand_dims, expand_dims=N)`` (the
+* ``NumExpandDim(u=..., axis=N)`` →
+  ``NumOp(u=..., fun=np.expand_dims, expand_dims=N)`` (the
   ``expand_dims`` kwarg already exists on :class:`~ams.core.service.NumOp`).
-* ``VarReduction(u=…, fun=np.ones)`` → build the shape-only
+* ``VarReduction(u=..., fun=np.ones)`` → build the shape-only
   reduction matrix inline, e.g. ``np.ones((1, u.n))``.
 
 **Internal — shared scalar-wrap helper:**

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -161,6 +161,27 @@ a stored value). Class definitions are regrouped by category
 (generic ops → subset/aggregation → reduction/difference →
 domain-specific → backward-compat aliases). No public API changes.
 
+**Deprecation — service classes with no production users:**
+
+:class:`~ams.core.service.NumExpandDim` and
+:class:`~ams.core.service.VarReduction` now emit
+``DeprecationWarning`` on instantiation and will be removed in
+v1.4.0. Both have zero call sites in :mod:`ams.routines` and
+:mod:`ams.core`. Replacements:
+
+* ``NumExpandDim(u=…, axis=N)`` →
+  ``NumOp(u=…, fun=np.expand_dims, expand_dims=N)`` (the
+  ``expand_dims`` kwarg already exists on :class:`~ams.core.service.NumOp`).
+* ``VarReduction(u=…, fun=np.ones)`` → build the shape-only
+  reduction matrix inline, e.g. ``np.ones((1, u.n))``.
+
+**Internal — shared scalar-wrap helper:**
+
+:class:`~ams.core.service.NumOp` and
+:class:`~ams.core.service.NumOpDual` ``v0`` properties now share a
+module-level ``_ensure_array`` helper rather than carrying
+near-identical scalar-to-ndarray wrap blocks. Behavior unchanged.
+
 v1.2
 ==========
 

--- a/tests/core/test_service.py
+++ b/tests/core/test_service.py
@@ -112,12 +112,19 @@ class TestServiceDeprecations(unittest.TestCase):
     def test_NumExpandDim_warns_on_init(self):
         rp = RParam(v=np.array([1.0, 2.0, 3.0]))
         with pytest.warns(DeprecationWarning, match="NumExpandDim"):
-            NumExpandDim(u=rp, axis=0)
+            svc = NumExpandDim(u=rp, axis=0)
+        # users who silence the warning still depend on .v correctness
+        # — pin output equality with the documented replacement so the
+        # v1.4.0 removal can verify migration parity
+        np.testing.assert_array_equal(
+            svc.v, np.expand_dims(rp.v, axis=0))
 
     def test_VarReduction_warns_on_init(self):
         rp = RParam(v=np.array([1.0, 2.0, 3.0]))
         with pytest.warns(DeprecationWarning, match="VarReduction"):
-            VarReduction(u=rp, fun=np.ones)
+            svc = VarReduction(u=rp, fun=np.ones)
+        # output parity with the documented inline replacement
+        np.testing.assert_array_equal(svc.v0, np.ones((1, rp.n)))
 
     def test_module_import_does_not_warn(self):
         """Importing ``ams.core.service`` must not raise the deprecation

--- a/tests/core/test_service.py
+++ b/tests/core/test_service.py
@@ -1,11 +1,15 @@
 import unittest
+import warnings
+
 import numpy as np
+import pytest
 import scipy.sparse as sps
 
 import ams
 from ams.core.matprocessor import MParam
 from ams.core.param import RParam
-from ams.core.service import NumOp, NumOpDual, ZonalSum
+from ams.core.service import (NumExpandDim, NumOp, NumOpDual, VarReduction,
+                              ZonalSum)
 
 
 def _as_dense(x):
@@ -96,6 +100,33 @@ class TestService(unittest.TestCase):
         np.testing.assert_array_equal(ds.v.shape, (self.nR, self.nD))
         # check if the values are correct
         self.assertTrue(np.all(ds.v.sum(axis=1) <= np.array([self.nB, self.nB])))
+
+
+class TestServiceDeprecations(unittest.TestCase):
+    """
+    Pinned deprecation contracts for v1.3.0 service-module cleanup.
+    Both classes have zero production users in AMS; ``__init__`` must
+    emit ``DeprecationWarning`` and removal is slated for v1.4.0.
+    """
+
+    def test_NumExpandDim_warns_on_init(self):
+        rp = RParam(v=np.array([1.0, 2.0, 3.0]))
+        with pytest.warns(DeprecationWarning, match="NumExpandDim"):
+            NumExpandDim(u=rp, axis=0)
+
+    def test_VarReduction_warns_on_init(self):
+        rp = RParam(v=np.array([1.0, 2.0, 3.0]))
+        with pytest.warns(DeprecationWarning, match="VarReduction"):
+            VarReduction(u=rp, fun=np.ones)
+
+    def test_module_import_does_not_warn(self):
+        """Importing ``ams.core.service`` must not raise the deprecation
+        warning — only instantiation does."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            import importlib
+            import ams.core.service as svc
+            importlib.reload(svc)
 
 
 class TestRParam(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **Deprecate** `NumExpandDim` and `VarReduction`. Both classes have **zero call sites** under `ams/routines/` and `ams/core/`. Their `__init__` now emits `DeprecationWarning` (`stacklevel=2`); docstrings carry `.. deprecated:: 1.3.0`. Removal target is **v1.4.0**.
- **Extract** `_ensure_array(out)` as a module-level helper so `NumOp.v0` and `NumOpDual.v0` stop carrying near-duplicate scalar→ndarray wrap blocks.

Phase 2 + Phase 3 of `projects/service_module_cleanup/`. Phase 1 (docs + structure) shipped in #263.

## Replacements

| Deprecated form | Replacement |
|---|---|
| `NumExpandDim(u, axis=N)` | `NumOp(u, fun=np.expand_dims, expand_dims=N)` |
| `VarReduction(u, fun=np.ones)` | inline: `np.ones((1, u.n))` |

## Behavior preservation

`_ensure_array` is byte-equivalent to the inline blocks that previously lived in `NumOp.v0` / `NumOpDual.v0` (scalar → 1-element ndarray; lists/tuples → `np.asarray`; ndarray and scipy.sparse passthrough). `NumOpDual.v0` still applies its post-wrap sparse conversion as before — that quirk is left alone (out of scope; harmless because `csr_matrix(csr_matrix(x))` is idempotent).

## Test plan

- [x] `pytest tests/core/test_service.py -v` — 10 pass (was 7), including 3 new deprecation tests:
  - `test_NumExpandDim_warns_on_init` — `pytest.warns(DeprecationWarning, match="NumExpandDim")`
  - `test_VarReduction_warns_on_init` — `pytest.warns(DeprecationWarning, match="VarReduction")`
  - `test_module_import_does_not_warn` — guard that bare `import ams.core.service` does not fire either warning
- [x] `pytest tests/` — 398 passed
- [x] `cd docs && make html SPHINXOPTS="-W --keep-going"` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)