### PR TITLE
fix: close openpyxl read-only workbooks in migrate_timeslot (Windows handle leak)

### DIFF
--- a/tests/test_migrate_timeslot.py
+++ b/tests/test_migrate_timeslot.py
@@ -235,20 +235,25 @@ class TestXlsxAdapter(unittest.TestCase):
             self.assertEqual(summary['uc_load'], 2)
             self.assertTrue(summary['renamed'])
 
-            # Re-load and verify sheet names + content.
+            # Re-load and verify sheet names + content. ``read_only=True``
+            # holds an open file handle on Windows, so close explicitly
+            # before TemporaryDirectory cleanup tries to unlink the file.
             wb2 = openpyxl.load_workbook(str(src), read_only=True)
-            self.assertIn('EDSlot', wb2.sheetnames)
-            self.assertIn('UCSlot', wb2.sheetnames)
-            self.assertIn('EDSlotLoad', wb2.sheetnames)
-            self.assertIn('EDSlotGen', wb2.sheetnames)
-            self.assertIn('UCSlotLoad', wb2.sheetnames)
-            self.assertNotIn('EDTSlot', wb2.sheetnames)
-            self.assertNotIn('UCTSlot', wb2.sheetnames)
+            try:
+                self.assertIn('EDSlot', wb2.sheetnames)
+                self.assertIn('UCSlot', wb2.sheetnames)
+                self.assertIn('EDSlotLoad', wb2.sheetnames)
+                self.assertIn('EDSlotGen', wb2.sheetnames)
+                self.assertIn('UCSlotLoad', wb2.sheetnames)
+                self.assertNotIn('EDTSlot', wb2.sheetnames)
+                self.assertNotIn('UCTSlot', wb2.sheetnames)
 
-            edload_rows = list(wb2['EDSlotLoad'].iter_rows(values_only=True))
-            self.assertEqual(edload_rows[0], ('area', 'slot', 'sd'))
-            # 2 areas * 1 slot = 2 data rows.
-            self.assertEqual(len(edload_rows), 3)
+                edload_rows = list(wb2['EDSlotLoad'].iter_rows(values_only=True))
+                self.assertEqual(edload_rows[0], ('area', 'slot', 'sd'))
+                # 2 areas * 1 slot = 2 data rows.
+                self.assertEqual(len(edload_rows), 3)
+            finally:
+                wb2.close()
 
 
 class TestRenameLegacyKeys(unittest.TestCase):

--- a/tools/migrate_timeslot.py
+++ b/tools/migrate_timeslot.py
@@ -388,13 +388,18 @@ def _xlsx_sheet_to_rows(ws) -> list[dict]:
 def _xlsx_load(path: Path) -> tuple[dict, list]:
     """Read an xlsx case into a {sheet: [rows]} dict + sheet order."""
     import openpyxl
+    # ``read_only=True`` keeps an OS file handle open until close();
+    # on Windows that blocks any later in-place rewrite of ``path``.
     wb = openpyxl.load_workbook(str(path), read_only=True, data_only=True)
-    data = {}
-    sheet_order = []
-    for sname in wb.sheetnames:
-        sheet_order.append(sname)
-        data[sname] = _xlsx_sheet_to_rows(wb[sname])
-    return data, sheet_order
+    try:
+        data = {}
+        sheet_order = []
+        for sname in wb.sheetnames:
+            sheet_order.append(sname)
+            data[sname] = _xlsx_sheet_to_rows(wb[sname])
+        return data, sheet_order
+    finally:
+        wb.close()
 
 
 def _xlsx_dump(path: Path, data: dict, sheet_order: list) -> None:


### PR DESCRIPTION
## Summary

Two leaks of ``openpyxl.load_workbook(..., read_only=True)`` handles
that Windows file-locking turns into hard errors:

1. **Production** — ``tools/migrate_timeslot.py::_xlsx_load`` opens
   the input workbook in ``read_only=True`` mode and never closes
   it. On Windows, the leaked handle blocks the in-place rewrite
   ``migrate_xlsx(p, p)`` — i.e. the documented usage —
   intermittently or with a ``PermissionError``.
2. **Test** — ``tests/test_migrate_timeslot.py::TestXlsxAdapter``
   does the same in its assertions, blocking
   ``TemporaryDirectory`` cleanup on Windows.

POSIX (macOS, Linux) silently allows unlinking open files, so both
leaks went unnoticed locally. Confirmed pre-existing — PR #262's
own Windows CI cells failed at merge time and the failures were
missed.

## Fix

Wrap each ``read_only=True`` workbook in ``try`` / ``finally`` +
``.close()``.

## Test plan

- [x] Local: ``pytest tests/test_migrate_timeslot.py`` passes (macOS).
- [ ] CI Windows cells turn green on this PR.
- [ ] After merge: refresh ``release/v1.3.0`` from develop and re-run #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)