### PR TITLE
docs: open v1.3.1 release-notes section on develop

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -9,6 +9,11 @@ The APIs before v3.0.0 are in beta and may change without prior notice.
 v1.3
 ==========
 
+v1.3.1 (date TBD)
+----------------------
+
+(Pre-release — items here will ship in the next v1.3.x patch.)
+
 v1.3.0 (2026-05-03)
 ----------------------
 


### PR DESCRIPTION
## Summary

Adds an empty ``v1.3.1 (date TBD)`` section above the just-released
``v1.3.0`` block, per the incremental-release-notes convention —
always carry an unreleased section on develop so RTD shows pending
changes for the next patch.

No content yet; future patch-level changes against develop will land
here.

## Test plan

- [x] Sphinx ``-W`` build clean locally (RST formatting).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)