### PR TITLE
fix(ptdf): enforce line flow limits on PTDF flow; clarify connectivity-matrix contract

### DIFF
--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -311,13 +311,30 @@ class MatProcessor:
 
         Notes
         -----
-        Generator online status is NOT considered in ``Cg`` — it is a
-        purely structural gen-to-bus map, because generator commitment
-        is a decision variable in the UC routines (status is applied via
-        ``ug``/``ugd`` instead). The load, line, and shunt connectivity
-        matrices (``Cl``, ``Cft``, ``Csh``) currently DO filter by their
-        element ``u`` status; reconciling them with this contract is a
-        tracked follow-up.
+        **Connectivity matrix design criterion:**
+        If an element's online/offline status is a *decision variable* in
+        the optimization (e.g. generator commitment ``ugd`` in UC), its
+        connectivity matrix must be a purely structural map — baking status
+        into the matrix would make a unit invisible to the network even after
+        the solver re-commits it. If status is *fixed at solve time* (i.e.
+        not a decision variable), filtering by ``u`` in the matrix is
+        equivalent to zeroing the corresponding parameter and is acceptable.
+
+        Under this criterion:
+
+        - ``Cg`` is structural (status-independent): generator commitment is
+          a decision variable in UC routines, so status is applied via
+          capacity bounds on ``pg``, not by zeroing columns of ``Cg``.
+        - ``Cl``, ``Csh``, ``Cft`` filter by element ``u`` status: load,
+          shunt, and line status are not decision variables in current AMS
+          routines; matrices are rebuilt via ``update()`` whenever status
+          changes, so the filtered matrices remain consistent at solve time.
+
+        A future structural refactor could make all four matrices
+        status-independent (status applied uniformly via per-element
+        parameters / bounds), which would also require making ``Bf``
+        structural (``u * b`` weighting instead of row filtering). Tracked
+        in ``projects/matprocessor_structural_connectivity``.
 
         Returns
         -------
@@ -402,6 +419,13 @@ class MatProcessor:
         -------
         Cl : scipy.sparse.csr_matrix
             Load connectivity matrix.
+
+        Notes
+        -----
+        Load online status (``PQ.u``) is applied here by excluding offline
+        loads from ``Cl``. Load status is not a decision variable in current
+        AMS routines, so this is equivalent to zeroing their contribution.
+        See ``build`` Notes for the design criterion.
         """
         system = self.system
 
@@ -431,6 +455,12 @@ class MatProcessor:
         -------
         Csh : spmatrix
             Shunt connectivity matrix.
+
+        Notes
+        -----
+        Shunt online status (``Shunt.u``) is applied here by excluding
+        offline shunts from ``Csh``. Shunt status is not a decision variable
+        in current AMS routines. See ``build`` Notes for the design criterion.
         """
         system = self.system
 
@@ -461,6 +491,14 @@ class MatProcessor:
         -------
         Cft : scipy.sparse.csr_matrix
             Line connectivity matrix.
+
+        Notes
+        -----
+        Line online status (``Line.u``) is applied here by excluding offline
+        lines from ``Cft`` and ``CftT``. ``Bf`` also excludes offline lines,
+        so the two matrices stay consistent. Line status is not a decision
+        variable in current AMS routines (no SCOPF / line switching).
+        See ``build`` Notes for the design criterion.
         """
         system = self.system
 

--- a/ams/routines/dcopf2.py
+++ b/ams/routines/dcopf2.py
@@ -51,6 +51,11 @@ class PTDFBase:
         # Use PTDF matrix instead of Bf@aBus
         self.plf.e_str = "PTDF @ (Cg@pg - Cl@pd - Csh@gsh - Pbusinj)"
 
+        # Angle-difference limits reference aBus which is not a decision variable
+        # in the PTDF formulation (aBus is computed post-solve, not optimized).
+        self.alflb.is_disabled = True
+        self.alfub.is_disabled = True
+
         # --- rewrite nodal price ---
         # Energy price component (from power balance dual)
         self.pie = ExpressionCalc(info="Energy price",

--- a/ams/routines/ed2.py
+++ b/ams/routines/ed2.py
@@ -24,6 +24,16 @@ class PTDFMPBase(PTDFBase):
         # --- rewrite Expression plf: line flow---
         self.plf.e_str = "PTDF @ (Cg@pg - Cl@pds - Csh@gsh@tlv - Pbusinj@tlv)"
 
+        # ED.__init__ rewrites plflb/plfub to directly embed Bf@aBus + Pfinj@tlv.
+        # Restore the symbolic plf reference so the PTDF flow is what is bounded.
+        self.plflb.e_str = '-plf - cp.multiply(ul, rate_a)@tlv <= 0'
+        self.plfub.e_str = 'plf - cp.multiply(ul, rate_a)@tlv <= 0'
+        # alflb/alfub reference aBus which is not a decision variable in the
+        # PTDF formulation. PTDFBase already disables them; state this
+        # explicitly here so the intent is clear at this level.
+        self.alflb.is_disabled = True
+        self.alfub.is_disabled = True
+
     def _post_solve(self):
         if self.aBus.horizon is not None:
             # Calculate bus angles after solving

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -34,25 +34,32 @@ not enforcing these constraints.
 
 **Fix — PTDF routines had vacuous line/angle limits:**
 
-The 2nd-generation PTDF routines (``ED2``, ``ED2DG``, ``ED2ES``,
-``UC2``, ``UC2DG``, ``UC2ES``, ``DCOPF2``) inherited line-flow and
-angle-difference limit constraints from the 1st-generation
-(angle-based) formulation. In the angle formulation the limit
-constraints embed the bus-voltage-angle variable ``aBus``; in the
-PTDF formulation ``aBus`` is not a decision variable (it is computed
-post-solve), so the solver was free to pick any ``aBus`` that
-trivialized those constraints. As a result, the line-flow and angle
-limits were present in the model but enforced nothing on the actual
-dispatch. On uncongested cases (like the bundled ``pjm5bus_demo``)
-the dispatch was coincidentally correct; a congested case would
-silently violate real line limits.
+The 2nd-generation PTDF routines inherit limit constraints from the
+1st-generation (angle-based) formulation that embed the
+bus-voltage-angle variable ``aBus``. In the PTDF formulation ``aBus``
+is not a decision variable (it is computed post-solve), so the solver
+was free to pick any ``aBus`` that trivialized those constraints.
+Two distinct defects:
+
+- **``plflb``/``plfub`` (multi-period routines: ``ED2``, ``ED2DG``,
+  ``ED2ES``, ``UC2``, ``UC2DG``, ``UC2ES``):** ``ED.__init__`` and
+  ``UC.__init__`` override these constraints to directly embed
+  ``Bf@aBus + Pfinj`` in the expression string. ``PTDFMPBase``
+  overrides ``plf.e_str`` to the PTDF formula but never overrides
+  the constraint strings — so the flow limits constrained the free
+  ``aBus``, not the actual PTDF dispatch. On uncongested cases the
+  dispatch was coincidentally correct; a congested case would
+  silently violate real line limits.
+- **``alflb``/``alfub`` (all PTDF routines including ``DCOPF2``):**
+  angle-difference limits reference ``aBus`` directly and are vacuous
+  for the same reason. These are disabled throughout the PTDF
+  hierarchy since they have no meaningful counterpart when ``aBus``
+  is not an optimization variable.
 
 The fix re-expresses ``plflb``/``plfub`` for the multi-period PTDF
-routines in terms of the correct PTDF flow expression (``plf``
-already pointed to the PTDF formula), and disables the
-angle-difference constraints (``alflb``/``alfub``) throughout the
-PTDF hierarchy since they have no meaningful counterpart when
-``aBus`` is not an optimization variable.
+routines using the symbolic ``plf`` reference (which already resolves
+to the correct PTDF flow expression for each subclass), and disables
+``alflb``/``alfub`` in ``PTDFBase.__init__``.
 
 **Fix — generator connectivity matrix ignored online status:**
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -32,6 +32,28 @@ This changes UC dispatch and objective values relative to v1.3.0 for
 cases where commitment would otherwise change — the prior results were
 not enforcing these constraints.
 
+**Fix — PTDF routines had vacuous line/angle limits:**
+
+The 2nd-generation PTDF routines (``ED2``, ``ED2DG``, ``ED2ES``,
+``UC2``, ``UC2DG``, ``UC2ES``, ``DCOPF2``) inherited line-flow and
+angle-difference limit constraints from the 1st-generation
+(angle-based) formulation. In the angle formulation the limit
+constraints embed the bus-voltage-angle variable ``aBus``; in the
+PTDF formulation ``aBus`` is not a decision variable (it is computed
+post-solve), so the solver was free to pick any ``aBus`` that
+trivialized those constraints. As a result, the line-flow and angle
+limits were present in the model but enforced nothing on the actual
+dispatch. On uncongested cases (like the bundled ``pjm5bus_demo``)
+the dispatch was coincidentally correct; a congested case would
+silently violate real line limits.
+
+The fix re-expresses ``plflb``/``plfub`` for the multi-period PTDF
+routines in terms of the correct PTDF flow expression (``plf``
+already pointed to the PTDF formula), and disables the
+angle-difference constraints (``alflb``/``alfub``) throughout the
+PTDF hierarchy since they have no meaningful counterpart when
+``aBus`` is not an optimization variable.
+
 **Fix — generator connectivity matrix ignored online status:**
 
 :meth:`~ams.core.matprocessor.MatProcessor.build_cg` filtered the

--- a/tests/routines/test_scenarios_lp_multiperiod.py
+++ b/tests/routines/test_scenarios_lp_multiperiod.py
@@ -215,3 +215,43 @@ def test_align(ctx):
 def test_pb_formula(ctx):
     """2nd-gen routines must use the non-angle pb formulation."""
     assert 'aBus' not in ctx.rtn.pb.e_str, f"Bus angle is used in {ctx.routine_id}.pb!"
+
+
+def test_congested_line_limit_ed2(pjm5bus_json):
+    """ED2 must enforce line flow limits under network congestion.
+
+    Tighten Line_2's rate_a below its unconstrained peak PTDF flow so the
+    limit actually binds during optimization.  Before the fix, the PTDF
+    routine constrained Bf@aBus (a free variable) instead of the PTDF flow,
+    making the limit vacuous.
+    """
+    ss = pjm5bus_json
+    ss.PQ.set(src='p0', attr='v', idx=['PQ_1', 'PQ_2'], value=[0.3, 0.3])
+    tight_limit = 0.65   # below peak unconstrained flow (~0.789)
+    ss.Line.set(src='rate_a', attr='v', idx='Line_2', value=tight_limit)
+
+    ss.ED.run(solver='CLARABEL')
+    assert ss.ED.converged, "ED did not converge under congestion!"
+    ss.ED2.update()
+    ss.ED2.run(solver='CLARABEL')
+    assert ss.ED2.converged, "ED2 did not converge under congestion!"
+
+    line_idx = ss.Line.idx.v
+    plf_ed2 = ss.ED2.get(src='plf', attr='v', idx=line_idx)
+    plf_ed = ss.ED.get(src='plf', attr='v', idx=line_idx)
+
+    # ED2 line flows must respect the tightened limit on Line_2
+    plf_l2 = ss.ED2.get(src='plf', attr='v', idx='Line_2')
+    assert np.all(np.abs(plf_l2) <= tight_limit + 1e-4), (
+        f"ED2 Line_2 flow {np.max(np.abs(plf_l2)):.4f} exceeds limit {tight_limit}"
+    )
+
+    # Objectives and flows must align between ED and ED2
+    np.testing.assert_almost_equal(
+        ss.ED2.obj.v, ss.ED.obj.v, decimal=3,
+        err_msg="ED2 objective does not match ED under congestion!",
+    )
+    np.testing.assert_almost_equal(
+        plf_ed2, plf_ed, decimal=3,
+        err_msg="ED2 line flows do not match ED under congestion!",
+    )

--- a/tests/routines/test_scenarios_milp_multiperiod.py
+++ b/tests/routines/test_scenarios_milp_multiperiod.py
@@ -233,3 +233,38 @@ def test_align(ctx):
 def test_pb_formula(ctx):
     """2nd-gen routines must use the non-angle pb formulation."""
     assert 'aBus' not in ctx.rtn.pb.e_str, f"Bus angle is used in {ctx.routine_id}.pb!"
+
+
+def test_congested_line_limit_uc2(pjm5bus_json):
+    """UC2 must enforce line flow limits under network congestion.
+
+    Tighten Line_2's rate_a below its unconstrained peak PTDF flow so the
+    limit actually binds during optimization.  Before the fix, the PTDF
+    routine constrained Bf@aBus (a free variable) instead of the PTDF flow,
+    making the limit vacuous.
+    """
+    if not HAS_MISOCP:
+        pytest.skip("No MISOCP solver is available.")
+
+    ss = pjm5bus_json
+    ss.PQ.set(src='p0', attr='v', idx=['PQ_1', 'PQ_2'], value=[0.3, 0.3])
+    tight_limit = 0.65   # below peak unconstrained flow (~0.789)
+    ss.Line.set(src='rate_a', attr='v', idx='Line_2', value=tight_limit)
+
+    ss.UC.run(solver=_SOLVER)
+    assert ss.UC.converged, "UC did not converge under congestion!"
+    ss.UC2.update()
+    ss.UC2.run(solver=_SOLVER)
+    assert ss.UC2.converged, "UC2 did not converge under congestion!"
+
+    # UC2 line flows must respect the tightened limit on Line_2
+    plf_l2 = ss.UC2.get(src='plf', attr='v', idx='Line_2')
+    assert np.all(np.abs(plf_l2) <= tight_limit + 1e-4), (
+        f"UC2 Line_2 flow {np.max(np.abs(plf_l2)):.4f} exceeds limit {tight_limit}"
+    )
+
+    # Objectives must align between UC2 and UC
+    np.testing.assert_almost_equal(
+        ss.UC2.obj.v, ss.UC.obj.v, decimal=3,
+        err_msg="UC2 objective does not match UC under congestion!",
+    )


### PR DESCRIPTION
## Summary

- **Bug fix:** PTDF routines (`ED2`, `ED2DG`, `ED2ES`, `UC2`, `UC2DG`, `UC2ES`, `DCOPF2`) had vacuous line-flow and angle-difference limit constraints. `ED.__init__` rewrites `plflb`/`plfub` to directly embed `Bf@aBus + Pfinj` in the constraint `e_str`; `PTDFMPBase.__init__` overrides `plf.e_str` to the PTDF expression but never overrides the constraints. Result: `aBus` (a free variable in the PTDF formulation) is what the limits constrained, not the actual dispatch flows. On the bundled `pjm5bus_demo` the optimum is non-congested so the bug was silent; a congested case would silently violate real line limits.
- **Fix:** In `PTDFMPBase.__init__`, restore `plflb`/`plfub` to reference `plf` symbolically (picks up `UC2`'s `pdu`-extended `plf` automatically). Disable `alflb`/`alfub` throughout the PTDF hierarchy (`PTDFBase` + `PTDFMPBase`) — angle-difference limits have no counterpart when `aBus` is not a decision variable.
- **Regression tests:** Two new congestion tests (tighten `Line_2` `rate_a` to 0.65 pu below peak PTDF flow ~0.789): one for `ED2` (CLARABEL), one for `UC2` (SCIP). Both assert line flow is bounded and objective matches the angle-based counterpart.
- **Docs:** Clarify `MatProcessor.build()` Notes with the design criterion for connectivity-matrix status handling (`Cg` structural because commitment is a decision variable; `Cl`/`Csh`/`Cft` filter by status because those are not decision variables). Per-method Notes added to `build_cl`, `build_csh`, `build_cft`.

## Test plan

- [x] 37 LP multiperiod tests pass (`test_scenarios_lp_multiperiod`)
- [x] 43 MILP multiperiod tests pass (`test_scenarios_milp_multiperiod`)
- [x] 369 remaining tests pass (full suite minus the above)
- [x] `flake8 ams/ tests/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)