### PR TITLE
fix(mats): structural connectivity matrices + ul-guard constraints + reserve rfun cleanup

### DIFF
--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -320,21 +320,18 @@ class MatProcessor:
         not a decision variable), filtering by ``u`` in the matrix is
         equivalent to zeroing the corresponding parameter and is acceptable.
 
-        Under this criterion:
+        Under this criterion, all connectivity matrices are structural:
 
-        - ``Cg`` is structural (status-independent): generator commitment is
-          a decision variable in UC routines, so status is applied via
-          capacity bounds on ``pg``, not by zeroing columns of ``Cg``.
-        - ``Cl``, ``Csh``, ``Cft`` filter by element ``u`` status: load,
-          shunt, and line status are not decision variables in current AMS
-          routines; matrices are rebuilt via ``update()`` whenever status
-          changes, so the filtered matrices remain consistent at solve time.
-
-        A future structural refactor could make all four matrices
-        status-independent (status applied uniformly via per-element
-        parameters / bounds), which would also require making ``Bf``
-        structural (``u * b`` weighting instead of row filtering). Tracked
-        in ``projects/matprocessor_structural_connectivity``.
+        - ``Cg`` is structural: generator commitment is a decision variable
+          in UC routines, so status is applied via capacity bounds on ``pg``.
+        - ``Cl`` is structural: offline loads are zeroed through the
+          effective demand ``pd`` / ``pds`` (multiplied by ``PQ.u``).
+        - ``Csh`` is structural: offline shunts are zeroed through the
+          effective conductance ``gsh`` (multiplied by ``Shunt.u``).
+        - ``Cft`` is structural: offline lines carry zero susceptance in
+          ``Bf`` (``b = u_line / x = 0``), so their power-balance
+          contribution is already zero. Angle-difference constraints
+          (``alflb``/``alfub``) multiply by ``ul`` to suppress offline rows.
 
         Returns
         -------
@@ -422,9 +419,9 @@ class MatProcessor:
 
         Notes
         -----
-        Load online status (``PQ.u``) is applied here by excluding offline
-        loads from ``Cl``. Load status is not a decision variable in current
-        AMS routines, so this is equivalent to zeroing their contribution.
+        ``Cl`` is a purely structural map (topology only). Offline load
+        contributions are zeroed through the effective demand parameter
+        ``gsh`` (``DCPFBase.pd``), which multiplies raw demand by ``PQ.u``.
         See ``build`` Notes for the design criterion.
         """
         system = self.system
@@ -435,14 +432,11 @@ class MatProcessor:
 
         # load indices: idx -> uid
         idx_load = system.PQ.idx.v
-        u_load = system.PQ.get(src='u', attr='v', idx=idx_load)
-        on_load = np.flatnonzero(u_load)
-        on_load_idx = [idx_load[i] for i in on_load]
-        on_load_bus = system.PQ.get(src='bus', attr='v', idx=on_load_idx)
+        all_load_bus = system.PQ.get(src='bus', attr='v', idx=idx_load)
 
-        row = np.array([system.Bus.idx2uid(x) for x in on_load_bus])
-        col = np.array([system.PQ.idx2uid(x) for x in on_load_idx])
-        self.Cl._v = sps.csr_matrix((np.ones(len(on_load_idx)), (row, col)), (nb, npq))
+        row = np.array([system.Bus.idx2uid(x) for x in all_load_bus])
+        col = np.array([system.PQ.idx2uid(x) for x in idx_load])
+        self.Cl._v = sps.csr_matrix((np.ones(len(idx_load)), (row, col)), (nb, npq))
         self.Cl.col_names = idx_load
         self.Cl.row_names = system.Bus.idx.v
         return self.Cl._v
@@ -458,9 +452,10 @@ class MatProcessor:
 
         Notes
         -----
-        Shunt online status (``Shunt.u``) is applied here by excluding
-        offline shunts from ``Csh``. Shunt status is not a decision variable
-        in current AMS routines. See ``build`` Notes for the design criterion.
+        ``Csh`` is a purely structural map (topology only). Offline shunt
+        contributions are zeroed through the effective conductance parameter
+        ``gsh`` (``DCPFBase.gsh``), which multiplies raw conductance by
+        ``Shunt.u``. See ``build`` Notes for the design criterion.
         """
         system = self.system
 
@@ -470,14 +465,11 @@ class MatProcessor:
 
         # shunt indices: idx -> uid
         idx_shunt = system.Shunt.idx.v
-        u_shunt = system.Shunt.get(src='u', attr='v', idx=idx_shunt)
-        on_shunt = np.flatnonzero(u_shunt)
-        on_shunt_idx = [idx_shunt[i] for i in on_shunt]
-        on_shunt_bus = system.Shunt.get(src='bus', attr='v', idx=on_shunt_idx)
+        all_shunt_bus = system.Shunt.get(src='bus', attr='v', idx=idx_shunt)
 
-        row = np.array([system.Bus.idx2uid(x) for x in on_shunt_bus])
-        col = np.array([system.Shunt.idx2uid(x) for x in on_shunt_idx])
-        self.Csh._v = sps.csr_matrix((np.ones(len(on_shunt_idx)), (row, col)), (nb, nsh))
+        row = np.array([system.Bus.idx2uid(x) for x in all_shunt_bus])
+        col = np.array([system.Shunt.idx2uid(x) for x in idx_shunt])
+        self.Csh._v = sps.csr_matrix((np.ones(len(idx_shunt)), (row, col)), (nb, nsh))
         self.Csh.col_names = idx_shunt
         self.Csh.row_names = system.Bus.idx.v
         return self.Csh._v
@@ -494,10 +486,11 @@ class MatProcessor:
 
         Notes
         -----
-        Line online status (``Line.u``) is applied here by excluding offline
-        lines from ``Cft`` and ``CftT``. ``Bf`` also excludes offline lines,
-        so the two matrices stay consistent. Line status is not a decision
-        variable in current AMS routines (no SCOPF / line switching).
+        ``Cft`` is a purely structural map (topology only). Offline lines
+        carry zero susceptance in ``Bf`` (``b = u_line / x``), so their
+        contribution to power balance and line flow is already zero without
+        filtering ``Cft``. Angle-difference constraints (``alflb``/``alfub``)
+        multiply by ``ul`` to suppress offline line rows.
         See ``build`` Notes for the design criterion.
         """
         system = self.system
@@ -508,16 +501,13 @@ class MatProcessor:
 
         # line indices: idx -> uid
         idx_line = system.Line.idx.v
-        u_line = system.Line.get(src='u', attr='v', idx=idx_line)
-        on_line = np.flatnonzero(u_line)
-        on_line_idx = [idx_line[i] for i in on_line]
-        on_line_bus1 = system.Line.get(src='bus1', attr='v', idx=on_line_idx)
-        on_line_bus2 = system.Line.get(src='bus2', attr='v', idx=on_line_idx)
+        all_bus1 = system.Line.get(src='bus1', attr='v', idx=idx_line)
+        all_bus2 = system.Line.get(src='bus2', attr='v', idx=idx_line)
 
-        data_line = np.ones(2*len(on_line_idx))
-        data_line[len(on_line_idx):] = -1
-        row_line = np.array([system.Bus.idx2uid(x) for x in on_line_bus1 + on_line_bus2])
-        col_line = np.array([system.Line.idx2uid(x) for x in on_line_idx + on_line_idx])
+        data_line = np.ones(2 * nl)
+        data_line[nl:] = -1
+        row_line = np.array([system.Bus.idx2uid(x) for x in all_bus1 + all_bus2])
+        col_line = np.array([system.Line.idx2uid(x) for x in idx_line + idx_line])
         self.Cft._v = sps.csr_matrix((data_line, (row_line, col_line)), (nb, nl))
         self.CftT._v = self.Cft._v.T
         self.Cft.col_names = idx_line

--- a/ams/core/matprocessor.py
+++ b/ams/core/matprocessor.py
@@ -421,7 +421,7 @@ class MatProcessor:
         -----
         ``Cl`` is a purely structural map (topology only). Offline load
         contributions are zeroed through the effective demand parameter
-        ``gsh`` (``DCPFBase.pd``), which multiplies raw demand by ``PQ.u``.
+        ``pd`` (``DCPFBase.pd``), which multiplies raw demand by ``PQ.u``.
         See ``build`` Notes for the design criterion.
         """
         system = self.system

--- a/ams/routines/dcopf.py
+++ b/ams/routines/dcopf.py
@@ -131,9 +131,11 @@ class DCOPF(DCPFBase):
         self.plfub = Constraint(info='line flow upper bound',
                                 name='plfub', e_str='plf - cp.multiply(ul, rate_a) <= 0',)
         self.alflb = Constraint(info='line angle difference lower bound',
-                                name='alflb', e_str='-CftT@aBus + amin <= 0',)
+                                name='alflb',
+                                e_str='-cp.multiply(ul, CftT@aBus) + amin <= 0',)
         self.alfub = Constraint(info='line angle difference upper bound',
-                                name='alfub', e_str='CftT@aBus - amax <= 0',)
+                                name='alfub',
+                                e_str='cp.multiply(ul, CftT@aBus) - amax <= 0',)
         # NOTE: in CVXPY, dual_variables returns a list
         self.pi = ExpressionCalc(info='LMP, dual of <pb>',
                                  name='pi', unit='$/p.u.',

--- a/ams/routines/dcopf2.py
+++ b/ams/routines/dcopf2.py
@@ -22,6 +22,19 @@ class PTDFBase:
 
     This class provides PTDF parameters and methods for routines that need
     to use PTDF formulation instead of B-theta formulation.
+
+    Notes
+    -----
+    In the PTDF formulation, ``aBus`` (bus voltage angles) is **not** an
+    optimization variable. Line flows are computed directly from power
+    injections via the PTDF matrix; ``aBus`` is recovered post-solve via
+    back-substitution. As a consequence, angle-difference constraints
+    (``alflb``/``alfub``) — which reference ``CftT@aBus`` — are disabled:
+    they would be vacuous during optimization (``aBus`` is unbound) and
+    the theoretically correct transform to flow-domain constraints (using
+    ``plf_k = b_k * (theta_from - theta_to)``) is not implemented.
+    Users with binding angle-stability limits should use the B-theta
+    formulations (``DCOPF``, ``ED``, ``UC``) instead.
     """
 
     def __init__(self, system, config, **kwargs):

--- a/ams/routines/dcpf.py
+++ b/ams/routines/dcpf.py
@@ -31,10 +31,18 @@ class DCPFBase(RoutineBase):
                           unit='p.u.', model='StaticGen',
                           src='p0', no_parse=False,)
         # --- shunt ---
-        self.gsh = RParam(info='shunt conductance',
-                          name='gsh', tex_name=r'g_{sh}',
-                          model='Shunt', src='g',
+        self.gsh0 = RParam(info='shunt conductance (raw)',
+                           name='gsh0', tex_name=r'g_{sh,0}',
+                           model='Shunt', src='g',
+                           no_parse=True,)
+        self.ush = RParam(info='shunt connection status',
+                          name='ush', tex_name=r'u_{sh}',
+                          model='Shunt', src='u',
                           no_parse=True,)
+        self.gsh = NumOpDual(info='effective shunt conductance',
+                             name='gsh', tex_name=r'g_{sh}',
+                             u=self.gsh0, u2=self.ush,
+                             fun=np.multiply, no_parse=True,)
 
         self.buss = RParam(info='Bus slack',
                            name='buss', tex_name=r'B_{us,s}',

--- a/ams/routines/ed.py
+++ b/ams/routines/ed.py
@@ -7,7 +7,6 @@ import numpy as np
 from ams.core.param import RParam
 from ams.core.service import (NumOpDual, NumHstack,
                               RampSub, NumOp, LoadScale)
-from ams.utils.func import multiply_left_t
 
 from ams.routines.rted import RTED, DGBase, ESD1Base
 
@@ -38,10 +37,11 @@ class SRBase:
                        model='StaticGen', nonneg=True,)
 
         self.dsrpz = NumOpDual(u=self.pdz, u2=self.dsrp, fun=np.multiply,
+                               rfun=np.transpose,
                                name='dsrpz', tex_name=r'd_{s,r, p, z}',
                                info='zonal spinning reserve requirement in percentage',)
         self.dsr = NumOpDual(u=self.dsrpz, u2=self.sd,
-                             fun=multiply_left_t,
+                             fun=np.multiply,
                              name='dsr', tex_name=r'd_{s,r,z}',
                              info='zonal spinning reserve requirement',)
 

--- a/ams/routines/ed.py
+++ b/ams/routines/ed.py
@@ -187,8 +187,8 @@ class ED(SRBase, MPBase, RTED):
         self.plf.info = '2D Line flow'
         self.plflb.e_str = '-Bf@aBus - Pfinj@tlv - cp.multiply(ul, rate_a)@tlv <= 0'
         self.plfub.e_str = 'Bf@aBus + Pfinj@tlv - cp.multiply(ul, rate_a)@tlv <= 0'
-        self.alflb.e_str = '-CftT@aBus + amin@tlv <= 0'
-        self.alfub.e_str = 'CftT@aBus - amax@tlv <= 0'
+        self.alflb.e_str = '-cp.multiply(ul, CftT@aBus) + amin@tlv <= 0'
+        self.alfub.e_str = 'cp.multiply(ul, CftT@aBus) - amax@tlv <= 0'
 
         self.plf.e_str = 'Bf@aBus + Pfinj@tlv'
 

--- a/ams/routines/ed2.py
+++ b/ams/routines/ed2.py
@@ -14,6 +14,12 @@ logger = logging.getLogger(__name__)
 class PTDFMPBase(PTDFBase):
     """
     Extend :ref:`PTDFBase` for multi-period scheduling.
+
+    Notes
+    -----
+    Inherits the ``aBus`` non-decision-variable constraint from
+    :ref:`PTDFBase`: ``alflb``/``alfub`` are disabled here for the same
+    reason. See :ref:`PTDFBase` Notes for the design rationale.
     """
     def __init__(self, system, config, **kwargs):
         super().__init__(system, config, **kwargs)

--- a/ams/routines/uc.py
+++ b/ams/routines/uc.py
@@ -285,7 +285,7 @@ class UC(SRBase, NSRBase, MPBase, RTEDBase, DCOPF):
         self.plf.info = '2D Line flow'
         self.plflb.e_str = '-Bf@aBus - Pfinj - cp.multiply(ul, rate_a)@tlv <= 0'
         self.plfub.e_str = 'Bf@aBus + Pfinj - cp.multiply(ul, rate_a)@tlv <= 0'
-        self.alflb.e_str = '-cp.multiply(ul, CftT@aBus) - amax@tlv <= 0'
+        self.alflb.e_str = '-cp.multiply(ul, CftT@aBus) + amin@tlv <= 0'
         self.alfub.e_str = 'cp.multiply(ul, CftT@aBus) - amax@tlv <= 0'
 
         # --- unserved load ---

--- a/ams/routines/uc.py
+++ b/ams/routines/uc.py
@@ -9,7 +9,6 @@ import pandas as pd
 from ams.core.param import RParam
 from ams.core.service import (NumOp, NumOpDual,
                               MinDurWindow, MinDurInit)
-from ams.utils.func import multiply_left_t
 from ams.routines.dcopf import DCOPF
 from ams.routines.rted import RTEDBase
 from ams.routines.ed import SRBase, MPBase, ESD1MPBase, DGMPBase
@@ -41,10 +40,11 @@ class NSRBase:
                         model='StaticGen', nonneg=True,)
 
         self.dnsrpz = NumOpDual(u=self.pdz, u2=self.dnsrp, fun=np.multiply,
+                                rfun=np.transpose,
                                 name='dnsrpz', tex_name=r'd_{nsr, p, z}',
                                 info='zonal non-spinning reserve requirement in percentage',)
         self.dnsr = NumOpDual(u=self.dnsrpz, u2=self.sd,
-                              fun=multiply_left_t,
+                              fun=np.multiply,
                               name='dnsr', tex_name=r'd_{nsr}',
                               info='zonal non-spinning reserve requirement',
                               no_parse=True,)

--- a/ams/routines/uc.py
+++ b/ams/routines/uc.py
@@ -283,10 +283,10 @@ class UC(SRBase, NSRBase, MPBase, RTEDBase, DCOPF):
         # --- line ---
         self.plf.horizon = self.timeslot
         self.plf.info = '2D Line flow'
-        self.plflb.e_str = '-Bf@aBus - Pfinj - cp.multiply(rate_a, tlv) <= 0'
-        self.plfub.e_str = 'Bf@aBus + Pfinj - cp.multiply(rate_a, tlv) <= 0'
-        self.alflb.e_str = '-CftT@aBus - amax@tlv <= 0'
-        self.alfub.e_str = 'CftT@aBus - amax@tlv <= 0'
+        self.plflb.e_str = '-Bf@aBus - Pfinj - cp.multiply(ul, rate_a)@tlv <= 0'
+        self.plfub.e_str = 'Bf@aBus + Pfinj - cp.multiply(ul, rate_a)@tlv <= 0'
+        self.alflb.e_str = '-cp.multiply(ul, CftT@aBus) - amax@tlv <= 0'
+        self.alfub.e_str = 'cp.multiply(ul, CftT@aBus) - amax@tlv <= 0'
 
         # --- unserved load ---
         self.pdu = Var(info='unserved demand',

--- a/ams/utils/func.py
+++ b/ams/utils/func.py
@@ -86,21 +86,3 @@ def str_list_iconv(x):
         x = x.split(',')
         return [item.strip() for item in x]
     raise NotImplementedError
-
-
-# ---------------------------------------------------------------------------
-# Numpy operator helpers
-# ---------------------------------------------------------------------------
-
-def multiply_left_t(a, b):
-    """
-    Return ``np.multiply(np.transpose(a), b)``.
-
-    Composes a small left-transpose with an element-wise multiply,
-    for cases where the natural shape of ``a`` is the transpose of
-    what numpy's broadcast rule needs against ``b``. Used by the
-    per-(area, slot) reserve chain in :class:`SRBase` /
-    :class:`NSRBase` so the v1.3.0 ``sd`` shape ``(narea, nslot)``
-    flows through without a NumOp(transpose) shim on the source side.
-    """
-    return np.multiply(np.transpose(a), b)

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -61,6 +61,35 @@ routines using the symbolic ``plf`` reference (which already resolves
 to the correct PTDF flow expression for each subclass), and disables
 ``alflb``/``alfub`` in ``PTDFBase.__init__``.
 
+**Connectivity matrices all structural; offline elements zeroed via parameters:**
+
+``Cl``, ``Csh``, and ``Cft`` previously filtered offline loads, shunts,
+and lines out of the matrix (matching the existing structural ``Cg``
+only in spirit). All four matrices are now purely structural (topology
+only), consistent with the design criterion established in v1.3.1:
+
+- **``Cl``** — offline load demand is zeroed through the effective demand
+  parameter ``pd`` / ``pds`` (``DCPFBase.pd = pd0 * PQ.u``; ``LoadScale``
+  already applies ``PQ.u``).
+- **``Csh``** — offline shunt conductance is zeroed through the new
+  effective conductance ``gsh = gsh0 * Shunt.u`` (``DCPFBase.gsh`` is
+  now a ``NumOpDual`` instead of a raw ``RParam``).
+- **``Cft``** — offline lines carry zero susceptance in ``Bf``
+  (``b = u_line / x``), so their power-balance and flow contribution
+  is already zero without filtering.
+- **Angle-difference constraints** (``alflb``/``alfub``) in B-theta
+  routines now multiply by ``ul`` so offline line rows are suppressed
+  (constraint is trivially satisfied when ``ul = 0``).
+
+**Fix — ``UC.plflb``/``plfub`` missing line-status factor:**
+
+``UC.__init__`` wrote the flow limits as
+``cp.multiply(rate_a, tlv)`` without the line-status factor ``ul``,
+inconsistent with ``DCOPF`` (which uses ``cp.multiply(ul, rate_a)``) and
+with the ``UC2`` fix in v1.3.1. The limits are now
+``cp.multiply(ul, rate_a)@tlv``, so offline lines have their rated
+flow set to zero (matching the zero flow from ``Bf``).
+
 **Fix — generator connectivity matrix ignored online status:**
 
 :meth:`~ams.core.matprocessor.MatProcessor.build_cg` filtered the


### PR DESCRIPTION
## Summary

- **Connectivity matrices all structural** — `Cl`, `Csh`, `Cft` now follow the same design as `Cg`: purely topological, with offline-element contributions zeroed through parameters/bounds rather than by filtering matrix columns.
- **`Csh` / `gsh` fix** — `DCPFBase.gsh` changed from a raw `RParam(Shunt.g)` to `NumOpDual(gsh0, ush, np.multiply)`, making it the effective shunt conductance (zero for offline shunts).
- **`alflb`/`alfub` guarded by `ul`** — angle-difference constraints in B-theta routines (`DCOPF`, `ED`, `UC`) now multiply by the line-status vector `ul`; offline line rows are trivially satisfied (`ul=0` → LHS = 0 ≤ amax).
- **`UC.plflb`/`plfub` missing `ul` factor** — fixed to `cp.multiply(ul, rate_a)@tlv`, consistent with `DCOPF` and the `UC2` fix from PR #269.
- **PTDF docstrings** — `PTDFBase` and `PTDFMPBase` gain a Notes block explaining that `aBus` is not an optimization variable, why `alflb`/`alfub` are disabled, and directing users with angle-stability limits to B-theta formulations.
- **`multiply_left_t` removed** — `SRBase.dsrpz` and `NSRBase.dnsrpz` now use `rfun=np.transpose` so the downstream `dsr`/`dnsr` can use plain `np.multiply`; the custom helper in `ams/utils/func.py` is deleted.

## Design criterion (from `MatProcessor.build()` Notes)

All connectivity matrices are now structural:
- `Cg` — structural because generator commitment is a UC decision variable.
- `Cl` — structural; offline loads zeroed via `pd`/`pds` (`pd0 * PQ.u`; `LoadScale` already applies `PQ.u`).
- `Csh` — structural; offline shunts zeroed via new `gsh = gsh0 * Shunt.u`.
- `Cft` — structural; offline lines carry zero susceptance in `Bf` (`b = u_line / x = 0`).

## Test plan

- [ ] `tests/routines/test_scenarios_lp_singleperiod.py` — all pass
- [ ] `tests/routines/test_scenarios_lp_multiperiod.py` — all pass (covers ED/ED2 congestion)
- [ ] `tests/routines/test_scenarios_milp_multiperiod.py` — all pass (covers UC/UC2)
- [ ] `tests/routines/test_uc_min_on_off.py` — all pass
- [ ] Full suite: 412/412 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)