### PR TITLE
feat(ci): Python 3.14 experimental + matrix scope reduction

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -8,9 +8,13 @@ jobs:
     continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ["3.11", "3.12", "3.13"]
         include:
+          - os: macos-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.13"
           - python-version: "3.14"
             os: ubuntu-latest
             experimental: true

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -50,7 +50,7 @@ jobs:
 
     - shell: bash -el {0}
       name: Lint with flake8
-      if: github.event_name == 'push' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
         flake8 .
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -5,10 +5,21 @@ on: [push, pull_request]
 jobs:
   compat:
     name: Tests
+    continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - python-version: "3.14"
+            os: ubuntu-latest
+            experimental: true
+          - python-version: "3.14"
+            os: macos-latest
+            experimental: true
+          - python-version: "3.14"
+            os: windows-latest
+            experimental: true
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: Coverage
 
-on: [push, pull_request]
+on: push
 
 jobs:
   cov:
@@ -30,12 +30,6 @@ jobs:
         python -m pip install -e .[dev,nlp]
 
     - shell: bash -el {0}
-      name: Lint with flake8
-      if: github.event_name == 'pull_request'
-      run: |
-        flake8 .
-
-    - shell: bash -el {0}
       name: Try installing optional packages
       run: |
         # Try installing one of the optional packages
@@ -59,7 +53,7 @@ jobs:
     - shell: bash -el {0}
       name: Test with pytest and collect coverage
       run: |
-        pytest --cov=./ --cov-report=xml
+        pytest -n auto --cov=./ --cov-report=xml
   
     - name: Upload coverage to Codacy
       if: steps.check_secret.outputs.is_set == 'true'

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,7 +27,6 @@ jobs:
     - shell: bash -el {0}
       name: Install dependencies
       run: |
-        mamba install -y nbmake pytest-xdist line_profiler  # add'l packages for notebook tests.
         python -m pip install -e .[dev,nlp]
 
     - shell: bash -el {0}
@@ -44,20 +43,9 @@ jobs:
         fi
 
     - shell: bash -el {0}
-      name: Lint with flake8
-      if: github.event_name == 'pull_request'
-      run: |
-        flake8 .
-
-    - shell: bash -el {0}
       name: Test with pytest
       run: |
         pytest
-
-    - shell: bash -el {0}
-      name: Test notebooks.
-      run: |
-        pytest --nbmake examples --ignore=examples/verification
 
   build:
     name: Build distribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Environment :: Console"
 ]


### PR DESCRIPTION
## Summary

Three CI improvements across four commits:

**Phase 1 — Add Python 3.14 (experimental)**
- `pyproject.toml`: add 3.14 classifier
- `compatibility.yml`: 3 new experimental cells (ubuntu/macos/windows × 3.14) with `continue-on-error: ${{ matrix.experimental == true }}`

**Phase 2 — Reduce required cells from 9 → 5 (plus pattern)**
- `compatibility.yml` base matrix: `ubuntu × {3.11, 3.12, 3.13}` + `macos×3.13` + `windows×3.13`
- Drops 4 redundant cells (macos-{3.11,3.12}, windows-{3.11,3.12}); Windows stays full-suite

**CI hygiene (A–E)**
- **A** — `coverage.yml` push-only trigger: eliminates duplicate ubuntu-3.11 pytest run on every PR
- **B** — `coverage.yml`: `pytest -n auto --cov` (xdist already installed; free speedup)
- **C+F** — `publish-pypi.yml` func job lightened: dead flake8 removed (condition `pull_request` was unreachable on a tag-only workflow); `mamba install nbmake/xdist/line_profiler` removed; `pytest --nbmake examples` removed (covered by `coverage.yml` on push); regular `pytest` kept as publish guard
- **E** — `compatibility.yml` flake8 now fires on push **and** PR (was push-only); `coverage.yml` flake8 step removed — one authoritative lint location

## Cell count after this PR

| | 3.11 | 3.12 | 3.13 | 3.14 (exp) |
|---|---|---|---|---|
| ubuntu | ✅ | ✅ | ✅ | ✅ |
| macos | — | — | ✅ | ✅ |
| windows | — | — | ✅ | ✅ |

**Before:** 9 required + 0 experimental  
**After:** 5 required + 3 experimental

## Event coverage after this PR

| Event | compatibility.yml | coverage.yml | publish-pypi.yml |
|---|---|---|---|
| push (branch) | full matrix | ubuntu-3.11 + cov + notebooks | — |
| pull_request | full matrix + flake8 | — | — |
| tag push | — | — | func (pytest) → build → publish |
| release published | — | — | zenodo.yml |

🤖 Generated with [Claude Code](https://claude.com/claude-code)